### PR TITLE
ympd is implemented only in C

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 2.6)
 
-project (ympd)
+project (ympd C)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${PROJECT_SOURCE_DIR}/cmake/")
 set(CPACK_PACKAGE_VERSION_MAJOR "1")
 set(CPACK_PACKAGE_VERSION_MINOR "2")


### PR DESCRIPTION
By default, CMake assumes that the project is using both C and C++. By
explicitly passing 'C' as argument of the project() macro, we tell
CMake that only C is used, which prevents CMake from checking if a C++
compiler exists.

Patch applied to buildroot since 2014:
https://git.buildroot.net/buildroot/commit/package/ympd?id=40aa523af26963321443a2d96c64ce128577ca77

Signed-off-by: Thomas Petazzoni <thomas.petazzoni@free-electrons.com>
Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>