### PR TITLE
Fixed invisible "Add all" button in browse page

### DIFF
--- a/htdocs/index.html
+++ b/htdocs/index.html
@@ -118,7 +118,6 @@
           </ol>
 
           <div class="col-md-12" id="filter">
-          <button id="add-all-songs" class="btn btn-primary pull-right">Add all</button>
           </div>
 
 

--- a/htdocs/js/mpd.js
+++ b/htdocs/js/mpd.js
@@ -78,6 +78,7 @@ var app = $.sammy(function() {
         socket.send('MPD_API_GET_BROWSE,'+pagination+','+(browsepath ? browsepath : "/"));
         // Don't add all songs from root
         if (browsepath) {
+            $('#filter').append('<button id="add-all-songs" class="btn btn-primary pull-right">Add all</button>');
             var add_all_songs = $('#add-all-songs');
             add_all_songs.off(); // remove previous binds
             add_all_songs.on('click', function() {


### PR DESCRIPTION
The button is in the "filter" element and the element is emptied each time the browse path is changed. The button should added in filter again after that.