### PR TITLE
Adding 'Prettier' and 'clang-format' linters

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,168 @@
+---
+Language:        Cpp
+# BasedOnStyle:  Google
+AccessModifierOffset: -1
+AlignAfterOpenBracket: Align
+AlignConsecutiveMacros: false
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Left
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: true
+AllowAllConstructorInitializersOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: None
+AllowShortLambdasOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: true
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: Yes
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterCaseLabel:  false
+  AfterClass:      false
+  AfterControlStatement: true
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  AfterExternBlock: false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Attach
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeColon
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     100
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DeriveLineEnding: true
+DerivePointerAlignment: true
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeBlocks:   Regroup
+IncludeCategories:
+  - Regex:           '^<ext/.*\.h>'
+    Priority:        2
+    SortPriority:    0
+  - Regex:           '^<.*\.h>'
+    Priority:        1
+    SortPriority:    0
+  - Regex:           '^<.*'
+    Priority:        2
+    SortPriority:    0
+  - Regex:           '.*'
+    Priority:        3
+    SortPriority:    0
+IncludeIsMainRegex: '([-_](test|unittest))?$'
+IncludeIsMainSourceRegex: ''
+IndentCaseLabels: true
+IndentGotoLabels: true
+IndentPPDirectives: None
+IndentWidth:     4
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Never
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
+PointerAlignment: Left
+RawStringFormats:
+  - Language:        Cpp
+    Delimiters:
+      - cc
+      - CC
+      - cpp
+      - Cpp
+      - CPP
+      - 'c++'
+      - 'C++'
+    CanonicalDelimiter: ''
+    BasedOnStyle:    google
+  - Language:        TextProto
+    Delimiters:
+      - pb
+      - PB
+      - proto
+      - PROTO
+    EnclosingFunctions:
+      - EqualsProto
+      - EquivToProto
+      - PARSE_PARTIAL_TEXT_PROTO
+      - PARSE_TEST_PROTO
+      - PARSE_TEXT_PROTO
+      - ParseTextOrDie
+      - ParseTextProtoOrDie
+    CanonicalDelimiter: ''
+    BasedOnStyle:    google
+ReflowComments:  true
+SortIncludes:    true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles:  false
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpaceBeforeSquareBrackets: false
+Standard:        Auto
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TabWidth:        8
+UseCRLF:         false
+UseTab:          Never
+...
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Build Artifacts
+build/

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,13 @@
+# Used by Prettier to ignore certain files and folders completely.
+# See https://prettier.io/docs/en/ignore.html for details.
+
+# Ignore build and system artifacts 
+build/
+cmake/
+contrib/
+
+# Ignore all 3rd party libraries
+**/bootstrap*
+**/jquery*
+**/modernizr*
+**/sammy*

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,20 @@
+{
+    "trailingComma": "es5",
+    "tabWidth": 4,
+    "semi": true,
+    "singleQuote": true,
+    "overrides": [
+        {
+            "files": ["*.html"],
+            "options": {
+                "tabWidth": 2
+            }
+        },
+        {
+            "files": ["*.css"],
+            "options": {
+                "tabWidth": 2
+            }
+        }
+    ]
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,16 +3,15 @@ language: c
 sudo: required
 dist: trusty
 
-compiler: 
-  - gcc
-  - clang
+compiler:
+    - gcc
+    - clang
 
 before_install:
-  - sudo apt-get -qq update
-  - sudo apt-get install -y libmpdclient-dev cmake
-  - mkdir build
-  - cd build
-  - cmake -D CMAKE_BUILD_TYPE=DEBUG ..
+    - sudo apt-get -qq update
+    - sudo apt-get install -y libmpdclient-dev cmake
+    - mkdir build
+    - cd build
+    - cmake -D CMAKE_BUILD_TYPE=DEBUG ..
 
 script: make
-

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -10,4 +10,23 @@ Manual Usage:
 > npx prettier --write .
 ```
 
-The C source and header files have been formatted with `clang-format`.
+The C source and header files have been formatted with `clang-format`. There's no easy way to manually execute the formatter on all of the C files at the same time. The clang format is based off of the 'Google' style with ajdustments to make the changes not as disruptive. See [.clang-format](./.clang-format) file for the formatting rules. Various editors should be able to automatically format the source on save.
+
+The only files formatted are the non-third party library files.
+
+Manual Usage:
+
+```bash
+> clang-format -i -style=file <filename>
+```
+
+Manually formatted files:
+
+-   http_server.c
+-   http_server.h
+-   json_encode.h
+-   mpd_client.c
+-   mpd_client.h
+-   ympd.c
+
+For help with the rules, see [Clang Format Configurator](https://zed0.co.uk/clang-format-configurator/) for an interactive tool and [ClangFormat](https://clang.llvm.org/docs/ClangFormat.html) for the rules reference.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,13 @@
+# Development Notes
+
+## Code Formatting
+
+The project has been formatted with [prettier.io](https://prettier.io/) for the HTML, JavaScript, CSS, and Markdown files. See the configuration file [.prettierrc.json](./.prettierrc.json) and the ignore file [.prettierignore](./.prettierignore) for details. If `prettier` is installed globally, there's no need to provide the various `npm`-type dependencies in the project. Various editors may provide plugins that can use this configuration without having to install `npm` and `prettier` manually.
+
+Manual Usage:
+
+```bash
+> npx prettier --write .
+```
+
+The C source and header files have been formatted with `clang-format`.

--- a/README.md
+++ b/README.md
@@ -4,28 +4,26 @@ ympd
 
 Standalone MPD Web GUI written in C, utilizing Websockets and Bootstrap/JS
 
-
 http://www.ympd.org
 
 ![ScreenShot](http://www.ympd.org/assets/ympd_github.png)
 
-Dependencies
-------------
- - libmpdclient 2: http://www.musicpd.org/libs/libmpdclient/
- - cmake 2.6: http://cmake.org/
- - OpenSSL: https://www.openssl.org/
+## Dependencies
 
-Unix Build Instructions
------------------------
+-   libmpdclient 2: http://www.musicpd.org/libs/libmpdclient/
+-   cmake 2.6: http://cmake.org/
+-   OpenSSL: https://www.openssl.org/
+
+## Unix Build Instructions
 
 1. install dependencies. cmake, libmpdclient (dev), and OpenSSL (dev) are available from all major distributions.
-2. create build directory ```cd /path/to/src; mkdir build; cd build```
-3. create makefile ```cmake ..  -DCMAKE_INSTALL_PREFIX:PATH=/usr```
-4. build ```make```
-5. install ```sudo make install``` or just run with ```./ympd```
+2. create build directory `cd /path/to/src; mkdir build; cd build`
+3. create makefile `cmake .. -DCMAKE_INSTALL_PREFIX:PATH=/usr`
+4. build `make`
+5. install `sudo make install` or just run with `./ympd`
 
-Run flags
----------
+## Run flags
+
 ```
 Usage: ./ympd [OPTION]...
 
@@ -39,21 +37,23 @@ Usage: ./ympd [OPTION]...
  --help                        this help
 ```
 
-SSL Support
------------
+## SSL Support
+
 To run ympd with SSL support:
 
-- create a certificate (key and cert in the same file), example:
+-   create a certificate (key and cert in the same file), example:
+
 ```
 # openssl req -x509 -newkey rsa:2048 -keyout key.pem -out cert.pem -days 1000 -nodes
 # cat key.pem cert.pem > ssl.pem
 ```
-- tell ympd to use a webport using SSL and where to find the certificate: 
+
+-   tell ympd to use a webport using SSL and where to find the certificate:
+
 ```
 # ./ympd -w "ssl://8081:/path/to/ssl.pem"
 ```
 
-Copyright
----------
+## Copyright
 
 2013-2014 <andy@ndyk.de>

--- a/htdocs/css/mpd.css
+++ b/htdocs/css/mpd.css
@@ -15,11 +15,9 @@ body {
   margin-bottom: 0;
 }
 
-
 button {
   overflow: hidden;
 }
-
 
 #volume-icon {
   float: left;
@@ -34,7 +32,7 @@ button {
   white-space: nowrap;
 }
 
-#breadcrump > li > a{
+#breadcrump > li > a {
   cursor: pointer;
 }
 
@@ -58,17 +56,17 @@ button {
   background-image: none;
   outline: 0;
   -webkit-box-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
-          box-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
+  box-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
   color: #428bca;
   background-color: #fdfdfd;
   border-color: #adadad;
 }
 
 @media (max-width: 1199px) {
-#btn-responsive-block > .btn {
-  padding: 6px 12px;
-  font-size: 14px;
-  border-radius: 4px;
+  #btn-responsive-block > .btn {
+    padding: 6px 12px;
+    font-size: 14px;
+    border-radius: 4px;
   }
 }
 
@@ -80,14 +78,16 @@ h1 {
   white-space: nowrap;
 }
 
-td:nth-child(4), th:nth-child(4) {
+td:nth-child(4),
+th:nth-child(4) {
   /* This *has* to be placed before
      any t[dh]:nth-last-child(2) for
      the override to work. */
   min-width: 50%;
 }
 
-td:nth-last-child(2), th:nth-last-child(2) {
+td:nth-last-child(2),
+th:nth-last-child(2) {
   text-align: right;
   width: 4em;
 }
@@ -98,7 +98,8 @@ td:nth-last-child(2), th:nth-last-child(2) {
   display: block;
 }
 
-td:nth-child(2), td:nth-child(3) {
+td:nth-child(2),
+td:nth-child(3) {
   min-width: 25%;
   max-width: 10em;
 
@@ -108,21 +109,24 @@ td:nth-child(2), td:nth-child(3) {
 }
 
 @media only screen and (max-width: 600px) {
-	td:nth-child(2), td:nth-child(3) {
-	  min-width: 0;
-	  max-width: 0;
-	}
-	td:nth-child(4), th:nth-child(4) {
-	  min-width: 10%;
-	  white-space: normal;
-	}
+  td:nth-child(2),
+  td:nth-child(3) {
+    min-width: 0;
+    max-width: 0;
+  }
+  td:nth-child(4),
+  th:nth-child(4) {
+    min-width: 10%;
+    white-space: normal;
+  }
 }
 
 tbody {
   cursor: pointer;
 }
 
-td:last-child, td:first-child {
+td:last-child,
+td:first-child {
   width: 30px;
 }
 
@@ -149,9 +153,9 @@ button {
 }
 
 #trashmode span:last-child {
-  display:inline-block;
-  text-align:left;
-  width:2.8em;
+  display: inline-block;
+  text-align: left;
+  width: 2.8em;
 }
 
 #filter > a.active {

--- a/htdocs/index.html
+++ b/htdocs/index.html
@@ -1,65 +1,110 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-  <meta charset="utf-8">
-  <meta http-equiv="X-UA-Compatible" content="IE=edge">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name="description" content="ympd - fast and lightweight MPD webclient">
-  <meta name="author" content="andy@ndyk.de">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="ympd - fast and lightweight MPD webclient"
+    />
+    <meta name="author" content="andy@ndyk.de" />
 
-  <title>ympd</title>
+    <title>ympd</title>
 
-  <!-- Bootstrap core CSS -->
-  <link href="css/bootstrap.css" rel="stylesheet">
-  <link href="css/bootstrap-theme.css" rel="stylesheet">
+    <!-- Bootstrap core CSS -->
+    <link href="css/bootstrap.css" rel="stylesheet" />
+    <link href="css/bootstrap-theme.css" rel="stylesheet" />
 
-  <!-- Custom styles for this template -->
-  <link href="css/mpd.css" rel="stylesheet">
-  <link href="assets/favicon.ico" rel="shortcut icon" type="image/vnd.microsoft.icon">
-  <script src="js/modernizr-custom.js"></script>
-</head>
-<body>
+    <!-- Custom styles for this template -->
+    <link href="css/mpd.css" rel="stylesheet" />
+    <link
+      href="assets/favicon.ico"
+      rel="shortcut icon"
+      type="image/vnd.microsoft.icon"
+    />
+    <script src="js/modernizr-custom.js"></script>
+  </head>
+  <body>
+    <div class="navbar navbar-inverse navbar-fixed-top" role="navigation">
+      <div class="container">
+        <div class="navbar-header">
+          <button
+            type="button"
+            class="navbar-toggle"
+            data-toggle="collapse"
+            data-target=".navbar-collapse"
+          >
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+          </button>
+          <a class="navbar-brand" href="/"
+            ><span class="glyphicon glyphicon-play-circle"></span> ympd</a
+          >
+        </div>
+        <div class="collapse navbar-collapse">
+          <ul id="nav_links" class="nav navbar-nav">
+            <li id="queue"><a href="#/">Queue</a></li>
+            <li id="browse"><a href="#/browse/0/">Browse</a></li>
+            <li>
+              <a href="#" data-toggle="modal" data-target="#addstream"
+                >Add Stream</a
+              >
+            </li>
+            <li>
+              <a
+                href="#"
+                data-toggle="modal"
+                data-target="#settings"
+                onclick="getHost();"
+                >Settings</a
+              >
+            </li>
+          </ul>
 
-  <div class="navbar navbar-inverse navbar-fixed-top" role="navigation">
-    <div class="container">
-      <div class="navbar-header">
-        <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
-          <span class="icon-bar"></span>
-          <span class="icon-bar"></span>
-          <span class="icon-bar"></span>
-        </button>
-        <a class="navbar-brand" href="/"><span class="glyphicon glyphicon-play-circle"></span> ympd</a>
-      </div>
-      <div class="collapse navbar-collapse">
-
-        <ul id="nav_links" class="nav navbar-nav">
-          <li id="queue"><a href="#/">Queue</a></li>
-          <li id="browse"><a href="#/browse/0/">Browse</a></li>
-          <li><a href="#" data-toggle="modal" data-target="#addstream">Add Stream</a></li>
-          <li><a href="#" data-toggle="modal" data-target="#settings" onclick="getHost();">Settings</a></li>
-        </ul>
-
-        <div class="btn-toolbar navbar-btn navbar-right" role="toolbar">
-          <div class="btn-group">
-            <button type="button" class="btn btn-default" onclick="socket.send('MPD_API_SET_PREV');">
-              <span class="glyphicon glyphicon-backward"></span>
-            </button>
-            <button type="button" class="btn btn-default" onclick="socket.send('MPD_API_SET_STOP');">
-              <span id="stop-icon" class="glyphicon glyphicon-stop"></span>
-            </button>
-            <button type="button" class="btn btn-default" onclick="clickPlay();">
-              <span id="play-icon" class="glyphicon glyphicon-pause"></span>
-            </button>
-            <button type="button" class="btn btn-default" onclick="socket.send('MPD_API_SET_NEXT');">
-              <span class="glyphicon glyphicon-forward"></span>
-            </button>
-          </div>
-          <div class="btn-group">
-            <button id="btnlove" type="button" class="btn btn-default" onclick="clickLove();">
-              <span class="glyphicon glyphicon-heart"></span>
-            </button>
-          </div>
-<!--          
+          <div class="btn-toolbar navbar-btn navbar-right" role="toolbar">
+            <div class="btn-group">
+              <button
+                type="button"
+                class="btn btn-default"
+                onclick="socket.send('MPD_API_SET_PREV');"
+              >
+                <span class="glyphicon glyphicon-backward"></span>
+              </button>
+              <button
+                type="button"
+                class="btn btn-default"
+                onclick="socket.send('MPD_API_SET_STOP');"
+              >
+                <span id="stop-icon" class="glyphicon glyphicon-stop"></span>
+              </button>
+              <button
+                type="button"
+                class="btn btn-default"
+                onclick="clickPlay();"
+              >
+                <span id="play-icon" class="glyphicon glyphicon-pause"></span>
+              </button>
+              <button
+                type="button"
+                class="btn btn-default"
+                onclick="socket.send('MPD_API_SET_NEXT');"
+              >
+                <span class="glyphicon glyphicon-forward"></span>
+              </button>
+            </div>
+            <div class="btn-group">
+              <button
+                id="btnlove"
+                type="button"
+                class="btn btn-default"
+                onclick="clickLove();"
+              >
+                <span class="glyphicon glyphicon-heart"></span>
+              </button>
+            </div>
+            <!--          
           <div class="btn-group">
             <div class="btn btn-toolbar btn-default">
               <span id="volume-icon" class="glyphicon glyphicon-volume-up"></span>
@@ -67,293 +112,493 @@
             </div>
           </div>
 -->
-           <div class="btn-group" role="group">
-            <audio id="player" preload="none"></audio>
-            <button type="button" class="btn btn-default" onclick="clickLocalPlay()">
-              <span id="localplay-icon" class="glyphicon glyphicon-play"></span>
-            </button>
-            <button type="button" class="btn btn-default" onclick="window.open('/player.html');">
-              <span id="localplay-icon" class="glyphicon glyphicon-new-window"></span>
-            </button>
+            <div class="btn-group" role="group">
+              <audio id="player" preload="none"></audio>
+              <button
+                type="button"
+                class="btn btn-default"
+                onclick="clickLocalPlay()"
+              >
+                <span
+                  id="localplay-icon"
+                  class="glyphicon glyphicon-play"
+                ></span>
+              </button>
+              <button
+                type="button"
+                class="btn btn-default"
+                onclick="window.open('/player.html');"
+              >
+                <span
+                  id="localplay-icon"
+                  class="glyphicon glyphicon-new-window"
+                ></span>
+              </button>
+            </div>
           </div>
-       </div>
-          
-        <form id="search" class="navbar-form navbar-right" role="search">
-          <div class="form-group">
-            <input type="text" class="form-control" placeholder="Search">
-          </div>
-        </form>
-      </div><!--/.nav-collapse -->
+
+          <form id="search" class="navbar-form navbar-right" role="search">
+            <div class="form-group">
+              <input type="text" class="form-control" placeholder="Search" />
+            </div>
+          </form>
+        </div>
+        <!--/.nav-collapse -->
+      </div>
     </div>
-  </div>
 
-  <div class="container starter-template">
-    <div class="row">
+    <div class="container starter-template">
+      <div class="row">
+        <div class="col-md-10 col-xs-12">
+          <div class="notifications top-right"></div>
 
-      <div class="col-md-10 col-xs-12">
-        <div class="notifications top-right"></div>
+          <div class="panel panel-primary">
+            <!-- Default panel contents -->
+            <div class="panel-heading">
+              <b id="panel-heading">Queue</b>
+              <b id="panel-heading-info" class="text pull-right"></b>
+            </div>
+            <div class="panel-body">
+              <h1>
+                <span
+                  id="track-icon"
+                  onclick="clickPlay();"
+                  class="glyphicon glyphicon-play"
+                ></span>
+                <span id="currenttrack"></span>
+              </h1>
+              <h4>
+                <span id="artist" class="text"></span>
+                <span id="album" class="text pull-right"></span>
+              </h4>
+              <p id="counter" class="text pull-right">&nbsp;&nbsp;</p>
 
-        <div class="panel panel-primary">
-          <!-- Default panel contents -->
-          <div class="panel-heading"><b id="panel-heading">Queue</b>
-                                     <b id="panel-heading-info" class="text pull-right"></b></div>
-          <div class="panel-body">
-            <h1>
-              <span id="track-icon" onclick="clickPlay();" class="glyphicon glyphicon-play"></span>
-              <span id="currenttrack"></span>
-            </h1>
+              <div id="progressbar"></div>
+            </div>
+            <!-- /.panel-body -->
+
+            <ol id="breadcrump" class="breadcrumb"></ol>
+
+            <div class="col-md-12" id="filter"></div>
+
+            <!-- Table -->
+            <table id="salamisandwich" class="table table-hover">
+              <thead>
+                <tr>
+                  <th>#</th>
+                  <th>Artist</th>
+                  <th>Album</th>
+                  <th>Title</th>
+                  <th>Length</th>
+                  <th></th>
+                </tr>
+              </thead>
+              <tbody></tbody>
+            </table>
+          </div>
+          <!-- /.panel -->
+          <ul class="pager">
+            <li id="prev" class="page-btn hide"><a href="">Previous</a></li>
+            <li id="next" class="page-btn"><a href="">Next</a></li>
+          </ul>
+        </div>
+        <!-- /.col-md-10 -->
+
+        <div class="col-md-2 col-xs-12">
+          <div class="btn-toolbar">
+            <div
+              class="btn-group-vertical btn-block btn-group-lg"
+              data-toggle="buttons"
+            >
+              <button id="btnrandom" type="button" class="btn btn-default">
+                <span class="glyphicon glyphicon-random"></span> Random
+              </button>
+              <button id="btnconsume" type="button" class="btn btn-default">
+                <span class="glyphicon glyphicon-fire"></span> Consume
+              </button>
+              <button id="btnsingle" type="button" class="btn btn-default">
+                <span class="glyphicon glyphicon-star"></span> Single
+              </button>
+              <button id="btncrossfade" type="button" class="btn btn-default">
+                <span class="glyphicon glyphicon-link"></span> Crossfade
+              </button>
+              <button id="btnrepeat" type="button" class="btn btn-default">
+                <span class="glyphicon glyphicon-repeat"></span> Repeat
+              </button>
+            </div>
+            <div
+              id="btn-outputs-block"
+              class="btn-group-vertical btn-block btn-group-lg"
+            ></div>
+
+            <div
+              id="trashmode"
+              class="btn-group-vertical btn-block btn-group-lg"
+              data-toggle="radio"
+            >
+              <button id="btntrashmodeup" type="button" class="btn btn-default">
+                <span class="glyphicon glyphicon-chevron-up"></span>
+                <span class="glyphicon glyphicon-trash"></span> <span>Up</span>
+              </button>
+              <button
+                id="btntrashmodesingle"
+                type="button"
+                class="btn btn-default active"
+              >
+                <span class="glyphicon glyphicon-star-empty"></span>
+                <span class="glyphicon glyphicon-trash"></span>
+                <span>Single</span>
+              </button>
+              <button
+                id="btntrashmodedown"
+                type="button"
+                class="btn btn-default"
+              >
+                <span class="glyphicon glyphicon-chevron-down"></span>
+                <span class="glyphicon glyphicon-trash"></span>
+                <span>Down</span>
+              </button>
+            </div>
+
+            <div
+              id="btn-responsive-block"
+              class="btn-group-vertical btn-block btn-group-lg"
+            >
+              <button
+                type="button"
+                class="btn btn-default"
+                onclick="socket.send('MPD_API_RM_ALL');"
+              >
+                <span class="glyphicon glyphicon-trash"></span> Clear Queue
+              </button>
+              <a
+                href="#"
+                data-toggle="modal"
+                data-target="#savequeue"
+                class="btn btn-default"
+              >
+                <span class="glyphicon glyphicon-save"></span> Save Queue
+              </a>
+            </div>
+          </div>
+        </div>
+        <!-- /.col-md-2 -->
+      </div>
+      <!-- /.row -->
+    </div>
+    <!-- /.container -->
+
+    <!-- Modal -->
+    <div
+      class="modal fade"
+      id="settings"
+      tabindex="-1"
+      role="dialog"
+      aria-labelledby="settingsLabel"
+      aria-hidden="true"
+    >
+      <div class="modal-dialog">
+        <div class="modal-content">
+          <div class="modal-header">
+            <button
+              type="button"
+              class="close"
+              data-dismiss="modal"
+              aria-hidden="true"
+            >
+              &times;
+            </button>
+            <h2 class="modal-title" id="settingsLabel">
+              <span class="glyphicon glyphicon-wrench"></span> Settings
+            </h2>
+          </div>
+          <div class="modal-body">
             <h4>
-              <span id="artist" class="text"></span>
-              <span id="album" class="text pull-right"></span>
+              <a href="http://www.ympd.org"
+                ><span class="glyphicon glyphicon-play-circle"></span> ympd</a
+              >&nbsp;&nbsp;&nbsp;<small
+                >MPD Web GUI - written in C, utilizing Websockets and
+                Bootstrap/JS</small
+              >
             </h4>
-            <p id="counter" class="text pull-right">&nbsp;&nbsp;</p>
-
-            <div id="progressbar"></div>
-
-
-          </div><!-- /.panel-body -->
-
-          <ol id="breadcrump" class="breadcrumb">
-          </ol>
-
-          <div class="col-md-12" id="filter">
-          </div>
-
-
-          <!-- Table -->
-          <table id="salamisandwich" class="table table-hover">
-            <thead>
-              <tr>
-                <th>#</th>
-                <th>Artist</th>
-                <th>Album</th>
-                <th>Title</th>
-                <th>Length</th>
-                <th></th>
-              </tr>
-            </thead>
-            <tbody>
-            </tbody>
-          </table>
-
-        </div><!-- /.panel -->
-        <ul class="pager">
-          <li id="prev" class="page-btn hide"><a href="">Previous</a></li>
-          <li id="next" class="page-btn"><a href="">Next</a></li>
-        </ul>
-      </div><!-- /.col-md-10 -->
-
-      <div class="col-md-2 col-xs-12">
-        <div class="btn-toolbar">
-          <div class="btn-group-vertical btn-block btn-group-lg" data-toggle="buttons">
-            <button id="btnrandom" type="button" class="btn btn-default">
-              <span class="glyphicon glyphicon-random"></span> Random
-            </button>
-            <button id="btnconsume" type="button" class="btn btn-default">
-              <span class="glyphicon glyphicon-fire"></span> Consume
-            </button>
-            <button id="btnsingle" type="button" class="btn btn-default">
-              <span class="glyphicon glyphicon-star"></span> Single
-            </button>
-            <button id="btncrossfade" type="button" class="btn btn-default">
-              <span class="glyphicon glyphicon-link"></span> Crossfade
-            </button>
-            <button id="btnrepeat" type="button" class="btn btn-default">
-              <span class="glyphicon glyphicon-repeat"></span> Repeat
-            </button>
-          </div>
-          <div id="btn-outputs-block" class="btn-group-vertical btn-block btn-group-lg">
-          </div>
-
-          <div id="trashmode" class="btn-group-vertical btn-block btn-group-lg" data-toggle="radio">
-            <button id="btntrashmodeup" type="button" class="btn btn-default">
-              <span class="glyphicon glyphicon-chevron-up"></span>
-              <span class="glyphicon glyphicon-trash"></span> <span>Up</span>
-            </button>
-            <button id="btntrashmodesingle" type="button" class="btn btn-default active">
-              <span class="glyphicon glyphicon-star-empty"></span>
-              <span class="glyphicon glyphicon-trash"></span> <span>Single</span>
-            </button>
-            <button id="btntrashmodedown" type="button" class="btn btn-default">
-              <span class="glyphicon glyphicon-chevron-down"></span>
-              <span class="glyphicon glyphicon-trash"></span> <span>Down</span>
-            </button>
-          </div>
-
-          <div id="btn-responsive-block" class="btn-group-vertical btn-block btn-group-lg">
-            <button type="button" class="btn btn-default" onclick="socket.send('MPD_API_RM_ALL');">
-              <span class="glyphicon glyphicon-trash"></span> Clear Queue
-            </button>
-            <a href="#" data-toggle="modal" data-target="#savequeue" class="btn btn-default">
-              <span class="glyphicon glyphicon-save"></span> Save Queue
-            </a>
-          </div>
-
-        </div>
-      </div><!-- /.col-md-2 -->
-    </div><!-- /.row -->
-  </div><!-- /.container -->
-
-  <!-- Modal -->
-  <div class="modal fade" id="settings" tabindex="-1" role="dialog" aria-labelledby="settingsLabel" aria-hidden="true">
-    <div class="modal-dialog">
-      <div class="modal-content">
-        <div class="modal-header">
-          <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-          <h2 class="modal-title" id="settingsLabel"><span class="glyphicon glyphicon-wrench"></span> Settings</h2>
-        </div>
-        <div class="modal-body">
-          <h4><a href="http://www.ympd.org"><span class="glyphicon glyphicon-play-circle"></span> ympd</a>&nbsp;&nbsp;&nbsp;<small>MPD Web GUI - written in C, utilizing Websockets and Bootstrap/JS</small></h4>
-          <p>
-          ympd is a lightweight MPD (Music Player Daemon) web client that runs without a dedicated webserver or interpreters like PHP, NodeJS or Ruby. It's tuned for minimal resource usage and requires only very litte dependencies.</p>
-          <h5>ympd uses following excellent software:</h5>
-          <h6><a href="http://cesanta.com/docs.html">Mongoose</a> <small>GPLv2</small></h6>
-          <h6><a href="http://www.musicpd.org/libs/libmpdclient/">libMPDClient</a> <small>BSD License</small></h6>
-          <hr />
-          <div class="row">
-            <div class="form-group col-md-6">
-              <button type="button" class="btn btn-default btn-block" onclick="updateDB();">
-                <span class="glyphicon glyphicon-refresh"></span> Update Database
-              </button>
-            </div>
-            <div class="form-group col-md-6" data-toggle="buttons">
-              <button type="button" class="btn btn-default btn-block" id="btnnotify">
-                <span class="glyphicon glyphicon-comment"></span> Enable Notifications
-              </button>
-            </div>
-          </div>
-          <hr />
-          <form role="form">
-            <div class="row">
-              <div class="form-group col-md-9">
-                <label class="control-label" for="mpdhost">MPD Host/IP</label>
-                <input type="text" class="form-control" id="mpdhost" />
-              </div>
-              <div class="form-group col-md-3">
-                <label class="control-label" for="mpdport">MPD Port</label>
-                <input type="text" class="form-control" id="mpdport" />
-              </div>
-            </div>
+            <p>
+              ympd is a lightweight MPD (Music Player Daemon) web client that
+              runs without a dedicated webserver or interpreters like PHP,
+              NodeJS or Ruby. It's tuned for minimal resource usage and requires
+              only very litte dependencies.
+            </p>
+            <h5>ympd uses following excellent software:</h5>
+            <h6>
+              <a href="http://cesanta.com/docs.html">Mongoose</a>
+              <small>GPLv2</small>
+            </h6>
+            <h6>
+              <a href="http://www.musicpd.org/libs/libmpdclient/"
+                >libMPDClient</a
+              >
+              <small>BSD License</small>
+            </h6>
+            <hr />
             <div class="row">
               <div class="form-group col-md-6">
-                <label class="control-label" for="mpd_pw">MPD Password</label>
-                <input type="password" class="form-control" id="mpd_pw" placeholder="Password"/>
+                <button
+                  type="button"
+                  class="btn btn-default btn-block"
+                  onclick="updateDB();"
+                >
+                  <span class="glyphicon glyphicon-refresh"></span> Update
+                  Database
+                </button>
               </div>
-              <div class="form-group col-md-6">
-                <label class="control-label" for="mpd_pw_con">MPD Password (Confirmation)</label>
-                <input type="password" class="form-control" id="mpd_pw_con"  placeholder="Confirmation"
-                data-placement="right" data-toggle="popover" data-content="Password does not match!"
-                data-trigger="manual" />
+              <div class="form-group col-md-6" data-toggle="buttons">
+                <button
+                  type="button"
+                  class="btn btn-default btn-block"
+                  id="btnnotify"
+                >
+                  <span class="glyphicon glyphicon-comment"></span> Enable
+                  Notifications
+                </button>
               </div>
-              <div class="form-group col-md-12">
-                <div id="mpd_password_set" class="hide alert alert-info">
-                  <button type="button" class="close" aria-hidden="true">&times;</button>
-                  MPD Password is set
+            </div>
+            <hr />
+            <form role="form">
+              <div class="row">
+                <div class="form-group col-md-9">
+                  <label class="control-label" for="mpdhost">MPD Host/IP</label>
+                  <input type="text" class="form-control" id="mpdhost" />
+                </div>
+                <div class="form-group col-md-3">
+                  <label class="control-label" for="mpdport">MPD Port</label>
+                  <input type="text" class="form-control" id="mpdport" />
                 </div>
               </div>
-            </div>
-            <div class="row">
-              <div class="form-group col-md-12">
-                <label class="control-label" for="mpdstream">MPD Stream URL</label>
-                <input type="text" class="form-control" id="mpdstream" />
+              <div class="row">
+                <div class="form-group col-md-6">
+                  <label class="control-label" for="mpd_pw">MPD Password</label>
+                  <input
+                    type="password"
+                    class="form-control"
+                    id="mpd_pw"
+                    placeholder="Password"
+                  />
+                </div>
+                <div class="form-group col-md-6">
+                  <label class="control-label" for="mpd_pw_con"
+                    >MPD Password (Confirmation)</label
+                  >
+                  <input
+                    type="password"
+                    class="form-control"
+                    id="mpd_pw_con"
+                    placeholder="Confirmation"
+                    data-placement="right"
+                    data-toggle="popover"
+                    data-content="Password does not match!"
+                    data-trigger="manual"
+                  />
+                </div>
+                <div class="form-group col-md-12">
+                  <div id="mpd_password_set" class="hide alert alert-info">
+                    <button type="button" class="close" aria-hidden="true">
+                      &times;
+                    </button>
+                    MPD Password is set
+                  </div>
+                </div>
               </div>
-            </div>
-          </form>
-          <div class="row">
-            <div class="form-group col-md-12" data-toggle="buttons">
-              <button type="button" class="btn btn-default btn-block" id="btnautoplay">
-                <span class="glyphicon glyphicon-play"></span> Autoplay stream in this browser when mpd is playing
-              </button>
+              <div class="row">
+                <div class="form-group col-md-12">
+                  <label class="control-label" for="mpdstream"
+                    >MPD Stream URL</label
+                  >
+                  <input type="text" class="form-control" id="mpdstream" />
+                </div>
+              </div>
+            </form>
+            <div class="row">
+              <div class="form-group col-md-12" data-toggle="buttons">
+                <button
+                  type="button"
+                  class="btn btn-default btn-block"
+                  id="btnautoplay"
+                >
+                  <span class="glyphicon glyphicon-play"></span> Autoplay stream
+                  in this browser when mpd is playing
+                </button>
+              </div>
             </div>
           </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-default" data-dismiss="modal">
+              Cancel
+            </button>
+            <button
+              type="button"
+              class="btn btn-default"
+              onclick="confirmSettings();"
+            >
+              Save
+            </button>
+          </div>
         </div>
-        <div class="modal-footer">
-          <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
-          <button type="button" class="btn btn-default" onclick="confirmSettings();">Save</button>
-        </div>
-      </div><!-- /.modal-content -->
-    </div><!-- /.modal-dialog -->
-  </div><!-- /.modal -->
+        <!-- /.modal-content -->
+      </div>
+      <!-- /.modal-dialog -->
+    </div>
+    <!-- /.modal -->
 
-  <!-- Modal -->
-  <div class="modal fade" id="addstream" tabindex="-1" role="dialog" aria-labelledby="addstreamLabel" aria-hidden="true">
-    <div class="modal-dialog">
-      <div class="modal-content">
-        <div class="modal-header">
-          <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-          <h2 class="modal-title" id="addstreamLabel"><span class="glyphicon glyphicon-wrench"></span> Add Stream</h2>
-        </div>
-        <div class="modal-body">
-          <form role="form">
-            <div class="row">
-              <div class="form-group col-md-12">
-                <label class="control-label" for="streamurl">Stream URL</label>
-                <input type="text" class="form-control" id="streamurl" />
+    <!-- Modal -->
+    <div
+      class="modal fade"
+      id="addstream"
+      tabindex="-1"
+      role="dialog"
+      aria-labelledby="addstreamLabel"
+      aria-hidden="true"
+    >
+      <div class="modal-dialog">
+        <div class="modal-content">
+          <div class="modal-header">
+            <button
+              type="button"
+              class="close"
+              data-dismiss="modal"
+              aria-hidden="true"
+            >
+              &times;
+            </button>
+            <h2 class="modal-title" id="addstreamLabel">
+              <span class="glyphicon glyphicon-wrench"></span> Add Stream
+            </h2>
+          </div>
+          <div class="modal-body">
+            <form role="form">
+              <div class="row">
+                <div class="form-group col-md-12">
+                  <label class="control-label" for="streamurl"
+                    >Stream URL</label
+                  >
+                  <input type="text" class="form-control" id="streamurl" />
+                </div>
               </div>
-            </div>
-          </form>
+            </form>
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-default" data-dismiss="modal">
+              Cancel
+            </button>
+            <button
+              type="button"
+              class="btn btn-default"
+              onclick="addStream();"
+            >
+              Add Stream
+            </button>
+          </div>
         </div>
-        <div class="modal-footer">
-          <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
-          <button type="button" class="btn btn-default" onclick="addStream();">Add Stream</button>
-        </div>
-      </div><!-- /.modal-content -->
-    </div><!-- /.modal-dialog -->
-  </div><!-- /.modal -->
+        <!-- /.modal-content -->
+      </div>
+      <!-- /.modal-dialog -->
+    </div>
+    <!-- /.modal -->
 
-  <div class="modal fade" id="savequeue" tabindex="-1" role="dialog" aria-labelledby="savequeueLabel" aria-hidden="true">
-    <div class="modal-dialog">
-      <div class="modal-content">
-        <div class="modal-header">
-          <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-          <h2 class="modal-title" id="savequeueLabel"><span class="glyphicon glyphicon-wrench"></span> Save Queue</h2>
-        </div>
-        <div class="modal-body">
-          <form role="form">
-            <div class="row">
-              <div class="form-group col-md-9">
-                <label class="control-label" for="playlistname">Playlist Name</label>
-                <input type="text" class="form-control" id="playlistname" />
+    <div
+      class="modal fade"
+      id="savequeue"
+      tabindex="-1"
+      role="dialog"
+      aria-labelledby="savequeueLabel"
+      aria-hidden="true"
+    >
+      <div class="modal-dialog">
+        <div class="modal-content">
+          <div class="modal-header">
+            <button
+              type="button"
+              class="close"
+              data-dismiss="modal"
+              aria-hidden="true"
+            >
+              &times;
+            </button>
+            <h2 class="modal-title" id="savequeueLabel">
+              <span class="glyphicon glyphicon-wrench"></span> Save Queue
+            </h2>
+          </div>
+          <div class="modal-body">
+            <form role="form">
+              <div class="row">
+                <div class="form-group col-md-9">
+                  <label class="control-label" for="playlistname"
+                    >Playlist Name</label
+                  >
+                  <input type="text" class="form-control" id="playlistname" />
+                </div>
               </div>
-            </div>
-          </form>
+            </form>
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-default" data-dismiss="modal">
+              Cancel
+            </button>
+            <button
+              type="button"
+              class="btn btn-default"
+              onclick="saveQueue();"
+            >
+              Save Queue
+            </button>
+          </div>
         </div>
-        <div class="modal-footer">
-          <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
-          <button type="button" class="btn btn-default" onclick="saveQueue();">Save Queue</button>
-        </div>
-      </div><!-- /.modal-content -->
-    </div><!-- /.modal-dialog -->
-  </div><!-- /.modal -->
+        <!-- /.modal-content -->
+      </div>
+      <!-- /.modal-dialog -->
+    </div>
+    <!-- /.modal -->
 
-  <div class="modal fade bs-example-modal-sm" id="wait" tabindex="-1" role="dialog" data-backdrop="static" data-keyboard="false" aria-hidden="true">
-    <div class="modal-dialog">
-      <div class="modal-content">
-        <div class="modal-header">
-          <h1>Searching...</h1>
-        </div>
-        <div class="modal-body">
-          <div class="progress progress-striped active">
-            <div class="progress-bar"  role="progressbar" aria-valuenow="45" aria-valuemin="0" aria-valuemax="100" style="width: 100%">
-              <span class="sr-only">Please Wait</span>
+    <div
+      class="modal fade bs-example-modal-sm"
+      id="wait"
+      tabindex="-1"
+      role="dialog"
+      data-backdrop="static"
+      data-keyboard="false"
+      aria-hidden="true"
+    >
+      <div class="modal-dialog">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h1>Searching...</h1>
+          </div>
+          <div class="modal-body">
+            <div class="progress progress-striped active">
+              <div
+                class="progress-bar"
+                role="progressbar"
+                aria-valuenow="45"
+                aria-valuemin="0"
+                aria-valuemax="100"
+                style="width: 100%"
+              >
+                <span class="sr-only">Please Wait</span>
+              </div>
             </div>
           </div>
         </div>
       </div>
     </div>
-  </div>
 
-
-  <!-- Bootstrap core JavaScript
+    <!-- Bootstrap core JavaScript
   ================================================== -->
-  <!-- Placed at the end of the document so the pages load faster -->
-  <script src="js/jquery-1.10.2.min.js"></script>
-  <script src="js/jquery.cookie.js"></script>
-  <script src="js/bootstrap.min.js"></script>
-  <script src="js/bootstrap-notify.js"></script>
-  <script src="js/bootstrap-slider.js"></script>
-  <script src="js/sammy.js"></script>
-  <script src="js/jquery-ui-sortable.min.js"></script>
-  <script src="js/mpd.js"></script>
-</body>
+    <!-- Placed at the end of the document so the pages load faster -->
+    <script src="js/jquery-1.10.2.min.js"></script>
+    <script src="js/jquery.cookie.js"></script>
+    <script src="js/bootstrap.min.js"></script>
+    <script src="js/bootstrap-notify.js"></script>
+    <script src="js/bootstrap-slider.js"></script>
+    <script src="js/sammy.js"></script>
+    <script src="js/jquery-ui-sortable.min.js"></script>
+    <script src="js/mpd.js"></script>
+  </body>
 </html>

--- a/htdocs/js/mpd.js
+++ b/htdocs/js/mpd.js
@@ -16,31 +16,30 @@
    Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-var TOKEN = "";
+var TOKEN = '';
 
 var socket;
 var last_state;
 var last_outputs;
 var current_app;
 var pagination = 0;
-var browsepath = "";
-var lastSongTitle = "";
+var browsepath = '';
+var lastSongTitle = '';
 var current_song = new Object();
 var MAX_ELEMENTS_PER_PAGE = 512;
 var isTouch = Modernizr.touch ? 1 : 0;
-var filter = "";
+var filter = '';
 
-var app = $.sammy(function() {
-
+var app = $.sammy(function () {
     function runBrowse() {
         current_app = 'queue';
 
         $('#breadcrump').addClass('hide');
         $('#filter').addClass('hide');
-        $('#salamisandwich').removeClass('hide').find("tr:gt(0)").remove();
-        socket.send('MPD_API_GET_QUEUE,'+pagination);
+        $('#salamisandwich').removeClass('hide').find('tr:gt(0)').remove();
+        socket.send('MPD_API_GET_QUEUE,' + pagination);
 
-        $('#panel-heading').text("Queue");
+        $('#panel-heading').text('Queue');
         $('#panel-heading-info').empty();
 
         $('#queue').addClass('active');
@@ -54,192 +53,246 @@ var app = $.sammy(function() {
         browsepath = '';
     }
 
-    this.get(/\#\/(\d+)/, function() {
+    this.get(/\#\/(\d+)/, function () {
         prepare();
         pagination = parseInt(this.params['splat'][0]);
         runBrowse();
     });
 
-    this.get(/\#\/browse\/(\d+)\/(.*)/, function() {
+    this.get(/\#\/browse\/(\d+)\/(.*)/, function () {
         prepare();
         browsepath = this.params['splat'][1];
         pagination = parseInt(this.params['splat'][0]);
         current_app = 'browse';
-        $('#breadcrump').removeClass('hide').empty().append("<li><a uri=\"\" onclick=\"set_filter('')\">root</a></li>");
-		add_filter();
-        $('#salamisandwich').removeClass('hide').find("tr:gt(0)").remove();
-        socket.send('MPD_API_GET_BROWSE,'+pagination+','+(browsepath ? browsepath : "/"));
+        $('#breadcrump')
+            .removeClass('hide')
+            .empty()
+            .append('<li><a uri="" onclick="set_filter(\'\')">root</a></li>');
+        add_filter();
+        $('#salamisandwich').removeClass('hide').find('tr:gt(0)').remove();
+        socket.send(
+            'MPD_API_GET_BROWSE,' +
+                pagination +
+                ',' +
+                (browsepath ? browsepath : '/')
+        );
         // Don't add all songs from root
         if (browsepath) {
-            $('#filter').append('<button id="add-all-songs" class="btn btn-primary pull-right">Add all</button>');
+            $('#filter').append(
+                '<button id="add-all-songs" class="btn btn-primary pull-right">Add all</button>'
+            );
             var add_all_songs = $('#add-all-songs');
-            add_all_songs.on('click', function() {
-                socket.send('MPD_API_ADD_TRACK,'+browsepath);
+            add_all_songs.on('click', function () {
+                socket.send('MPD_API_ADD_TRACK,' + browsepath);
             });
         }
 
-        $('#panel-heading').text("Browse database: "+browsepath);
+        $('#panel-heading').text('Browse database: ' + browsepath);
         var path_array = browsepath.split('/');
-        var full_path = "";
-        $.each(path_array, function(index, chunk) {
-            if(path_array.length - 1 == index) {
-                $('#breadcrump').append("<li class=\"active\">"+ chunk + "</li>");
+        var full_path = '';
+        $.each(path_array, function (index, chunk) {
+            if (path_array.length - 1 == index) {
+                $('#breadcrump').append(
+                    '<li class="active">' + chunk + '</li>'
+                );
                 return;
             }
 
             full_path = full_path + chunk;
-            $('#breadcrump').append("<li><a uri=\"" + full_path + "\">"+chunk+"</a></li>");
-            full_path += "/";
+            $('#breadcrump').append(
+                '<li><a uri="' + full_path + '">' + chunk + '</a></li>'
+            );
+            full_path += '/';
         });
         $('#browse').addClass('active');
     });
 
-    this.get(/\#\/search\/(.*)/, function() {
+    this.get(/\#\/search\/(.*)/, function () {
         current_app = 'search';
-        $('#salamisandwich').find("tr:gt(0)").remove();
+        $('#salamisandwich').find('tr:gt(0)').remove();
         var searchstr = this.params['splat'][0];
 
         $('#search > div > input').val(searchstr);
         socket.send('MPD_API_SEARCH,' + searchstr);
 
-        $('#panel-heading').text("Search: "+searchstr);
+        $('#panel-heading').text('Search: ' + searchstr);
     });
 
-    this.get("/", function(context) {
-        context.redirect("#/0");
+    this.get('/', function (context) {
+        context.redirect('#/0');
     });
 });
 
-$(document).ready(function(){
+$(document).ready(function () {
     webSocketConnect();
-    $("#volumeslider").slider(0);
-    $("#volumeslider").on('slider.newValue', function(evt,data){
-        socket.send("MPD_API_SET_VOLUME,"+data.val);
+    $('#volumeslider').slider(0);
+    $('#volumeslider').on('slider.newValue', function (evt, data) {
+        socket.send('MPD_API_SET_VOLUME,' + data.val);
     });
     $('#progressbar').slider(0);
-    $("#progressbar").on('slider.newValue', function(evt,data){
-        if(current_song && current_song.currentSongId >= 0) {
-            var seekVal = Math.ceil(current_song.totalTime*(data.val/100));
-            socket.send("MPD_API_SET_SEEK,"+current_song.currentSongId+","+seekVal);
+    $('#progressbar').on('slider.newValue', function (evt, data) {
+        if (current_song && current_song.currentSongId >= 0) {
+            var seekVal = Math.ceil(current_song.totalTime * (data.val / 100));
+            socket.send(
+                'MPD_API_SET_SEEK,' + current_song.currentSongId + ',' + seekVal
+            );
         }
     });
 
     $('#addstream').on('shown.bs.modal', function () {
         $('#streamurl').focus();
-     })
+    });
     $('#addstream form').on('submit', function (e) {
         addStream();
     });
 
-    if(!notificationsSupported())
-        $('#btnnotify').addClass("disabled");
-    else
-        if ($.cookie("notification") === "true")
-            $('#btnnotify').addClass("active")
+    if (!notificationsSupported()) $('#btnnotify').addClass('disabled');
+    else if ($.cookie('notification') === 'true')
+        $('#btnnotify').addClass('active');
 
-    if ($.cookie("autoplay") === "true")
-        $('#btnautoplay').addClass("active")
+    if ($.cookie('autoplay') === 'true') $('#btnautoplay').addClass('active');
 
-    document.getElementById('player').addEventListener('stalled', function() {
-						if ( !document.getElementById('player').paused ) {
-							this.pause();
-							clickLocalPlay();
-							$('.top-right').notify({
-								message:{text:"music stream stalled - trying to recover..."},
-								type: "danger",
-								fadeOut: { enabled: true, delay: 1000 },
-							}).show();
-						}
+    document.getElementById('player').addEventListener('stalled', function () {
+        if (!document.getElementById('player').paused) {
+            this.pause();
+            clickLocalPlay();
+            $('.top-right')
+                .notify({
+                    message: {
+                        text: 'music stream stalled - trying to recover...',
+                    },
+                    type: 'danger',
+                    fadeOut: { enabled: true, delay: 1000 },
+                })
+                .show();
+        }
     });
 
-    document.getElementById('player').addEventListener('pause', function() {
-        this.src='';
-        this.removeAttribute("src");
-    	$("#localplay-icon").removeClass("glyphicon-pause").addClass("glyphicon-play");
+    document.getElementById('player').addEventListener('pause', function () {
+        this.src = '';
+        this.removeAttribute('src');
+        $('#localplay-icon')
+            .removeClass('glyphicon-pause')
+            .addClass('glyphicon-play');
     });
 
-	document.getElementById('player').addEventListener('error', function failed(e) {
-		this.pause();
-		switch (e.target.error.code) {
-			case e.target.error.MEDIA_ERR_ABORTED:
-				$('.top-right').notify({
-					message:{text:"Audio playback aborted by user."},
-					type: "info",
-					fadeOut: { enabled: true, delay: 1000 },
-				}).show();
-				break;
-			case e.target.error.MEDIA_ERR_NETWORK:
-				$('.top-right').notify({
-					message:{text:"Network error while playing audio."},
-					type: "danger",
-					fadeOut: { enabled: true, delay: 1000 },
-				}).show();
-				break;
-			case e.target.error.MEDIA_ERR_DECODE:
-				$('.top-right').notify({
-					message:{text:"Audio playback aborted. Did you unplug your headphones?"},
-					type: "danger",
-					fadeOut: { enabled: true, delay: 1000 },
-				}).show();
-				break;
-			case e.target.error.MEDIA_ERR_SRC_NOT_SUPPORTED:
-				$('.top-right').notify({
-					message:{text:"Error while loading audio (server, network or format error)."},
-					type: "danger",
-					fadeOut: { enabled: true, delay: 1000 },
-				}).show();
-				break;
-			default:
-				$('.top-right').notify({
-					message:{text:"Unknown error while playing audio."},
-					type: "danger",
-					fadeOut: { enabled: true, delay: 1000 },
-				}).show();
-				break;
-		}
-	}, true);
+    document.getElementById('player').addEventListener(
+        'error',
+        function failed(e) {
+            this.pause();
+            switch (e.target.error.code) {
+                case e.target.error.MEDIA_ERR_ABORTED:
+                    $('.top-right')
+                        .notify({
+                            message: {
+                                text: 'Audio playback aborted by user.',
+                            },
+                            type: 'info',
+                            fadeOut: { enabled: true, delay: 1000 },
+                        })
+                        .show();
+                    break;
+                case e.target.error.MEDIA_ERR_NETWORK:
+                    $('.top-right')
+                        .notify({
+                            message: {
+                                text: 'Network error while playing audio.',
+                            },
+                            type: 'danger',
+                            fadeOut: { enabled: true, delay: 1000 },
+                        })
+                        .show();
+                    break;
+                case e.target.error.MEDIA_ERR_DECODE:
+                    $('.top-right')
+                        .notify({
+                            message: {
+                                text: 'Audio playback aborted. Did you unplug your headphones?',
+                            },
+                            type: 'danger',
+                            fadeOut: { enabled: true, delay: 1000 },
+                        })
+                        .show();
+                    break;
+                case e.target.error.MEDIA_ERR_SRC_NOT_SUPPORTED:
+                    $('.top-right')
+                        .notify({
+                            message: {
+                                text: 'Error while loading audio (server, network or format error).',
+                            },
+                            type: 'danger',
+                            fadeOut: { enabled: true, delay: 1000 },
+                        })
+                        .show();
+                    break;
+                default:
+                    $('.top-right')
+                        .notify({
+                            message: {
+                                text: 'Unknown error while playing audio.',
+                            },
+                            type: 'danger',
+                            fadeOut: { enabled: true, delay: 1000 },
+                        })
+                        .show();
+                    break;
+            }
+        },
+        true
+    );
 });
 
 function webSocketConnect() {
-    if (typeof MozWebSocket != "undefined") {
+    if (typeof MozWebSocket != 'undefined') {
         socket = new MozWebSocket(get_appropriate_ws_url());
     } else {
         socket = new WebSocket(get_appropriate_ws_url());
     }
 
     try {
-        socket.onopen = function() {
-            console.log("connected");
-            $('.top-right').notify({
-                message:{text:"Connected to ympd"},
-                fadeOut: { enabled: true, delay: 500 }
-            }).show();
+        socket.onopen = function () {
+            console.log('connected');
+            $('.top-right')
+                .notify({
+                    message: { text: 'Connected to ympd' },
+                    fadeOut: { enabled: true, delay: 500 },
+                })
+                .show();
 
             app.run();
             /* emit initial request for output names */
             socket.send('MPD_API_GET_OUTPUTS');
-        }
+        };
 
         socket.onmessage = function got_packet(msg) {
-            if(msg.data === last_state || msg.data.length == 0)
-                return;
+            if (msg.data === last_state || msg.data.length == 0) return;
 
             var obj = JSON.parse(msg.data);
-            
 
             switch (obj.type) {
                 case 'queue':
-                    if(current_app !== 'queue')
-                        break;
+                    if (current_app !== 'queue') break;
 
                     if (obj.totalTime > 0) {
                         var hours = Math.floor(obj.totalTime / 3600);
-                        var minutes = Math.floor(obj.totalTime / 60) - hours * 60;
-                        var seconds = obj.totalTime - hours * 3600 - minutes * 60;
+                        var minutes =
+                            Math.floor(obj.totalTime / 60) - hours * 60;
+                        var seconds =
+                            obj.totalTime - hours * 3600 - minutes * 60;
 
-                        $('#panel-heading-info').text('Total: ' +
-                            (hours > 0 ? hours + '\u2009h ' + (minutes < 10 ? '0' : '') : '') +
-                            minutes + '\u2009m ' + (seconds < 10 ? '0' : '') + seconds + '\u2009s');
+                        $('#panel-heading-info').text(
+                            'Total: ' +
+                                (hours > 0
+                                    ? hours +
+                                      '\u2009h ' +
+                                      (minutes < 10 ? '0' : '')
+                                    : '') +
+                                minutes +
+                                '\u2009m ' +
+                                (seconds < 10 ? '0' : '') +
+                                seconds +
+                                '\u2009s'
+                        );
                     } else {
                         $('#panel-heading-info').empty();
                     }
@@ -250,79 +303,138 @@ function webSocketConnect() {
                         var seconds = obj.data[song].duration - minutes * 60;
 
                         $('#salamisandwich > tbody').append(
-                            "<tr trackid=\"" + obj.data[song].id + "\"><td>" + (obj.data[song].pos + 1) + "</td>" +
-                                "<td>"+ obj.data[song].artist +"</td>" + 
-                                "<td>"+ obj.data[song].album +"</td>" +
-                                "<td>"+ obj.data[song].title +"</td>" +
-                                "<td>"+ minutes + ":" + (seconds < 10 ? '0' : '') + seconds +
-                        "</td><td></td></tr>");
+                            '<tr trackid="' +
+                                obj.data[song].id +
+                                '"><td>' +
+                                (obj.data[song].pos + 1) +
+                                '</td>' +
+                                '<td>' +
+                                obj.data[song].artist +
+                                '</td>' +
+                                '<td>' +
+                                obj.data[song].album +
+                                '</td>' +
+                                '<td>' +
+                                obj.data[song].title +
+                                '</td>' +
+                                '<td>' +
+                                minutes +
+                                ':' +
+                                (seconds < 10 ? '0' : '') +
+                                seconds +
+                                '</td><td></td></tr>'
+                        );
                     }
 
-                    if(obj.data.length && obj.data[obj.data.length-1].pos + 1 >= pagination + MAX_ELEMENTS_PER_PAGE)
+                    if (
+                        obj.data.length &&
+                        obj.data[obj.data.length - 1].pos + 1 >=
+                            pagination + MAX_ELEMENTS_PER_PAGE
+                    )
                         $('#next').removeClass('hide');
-                    if(pagination > 0)
-                        $('#prev').removeClass('hide');
-                    if ( isTouch ) {
-                        $('#salamisandwich > tbody > tr > td:last-child').append(
-                                    "<a class=\"pull-right btn-group-hover\" href=\"#/\" " +
-                                        "onclick=\"trash($(this).parents('tr'));\">" +
-                                "<span class=\"glyphicon glyphicon-trash\"></span></a>");
+                    if (pagination > 0) $('#prev').removeClass('hide');
+                    if (isTouch) {
+                        $(
+                            '#salamisandwich > tbody > tr > td:last-child'
+                        ).append(
+                            '<a class="pull-right btn-group-hover" href="#/" ' +
+                                'onclick="trash($(this).parents(\'tr\'));">' +
+                                '<span class="glyphicon glyphicon-trash"></span></a>'
+                        );
                     } else {
                         $('#salamisandwich > tbody > tr').on({
-                            mouseover: function(){
+                            mouseover: function () {
                                 var doomed = $(this);
-                                if ( $('#btntrashmodeup').hasClass('active') )
-                                    doomed = $("#salamisandwich > tbody > tr:lt(" + ($(this).index() + 1) + ")");
-                                if ( $('#btntrashmodedown').hasClass('active') )
-                                    doomed = $("#salamisandwich > tbody > tr:gt(" + ($(this).index() - 1) + ")");
-                                $.each(doomed, function(){
-                                if($(this).children().last().has("a").length == 0)
-                                    $(this).children().last().append(
-                                        "<a class=\"pull-right btn-group-hover\" href=\"#/\" " +
-                                            "onclick=\"trash($(this).parents('tr'));\">" +
-                                    "<span class=\"glyphicon glyphicon-trash\"></span></a>")
-                                .find('a').fadeTo('fast',1);
+                                if ($('#btntrashmodeup').hasClass('active'))
+                                    doomed = $(
+                                        '#salamisandwich > tbody > tr:lt(' +
+                                            ($(this).index() + 1) +
+                                            ')'
+                                    );
+                                if ($('#btntrashmodedown').hasClass('active'))
+                                    doomed = $(
+                                        '#salamisandwich > tbody > tr:gt(' +
+                                            ($(this).index() - 1) +
+                                            ')'
+                                    );
+                                $.each(doomed, function () {
+                                    if (
+                                        $(this).children().last().has('a')
+                                            .length == 0
+                                    )
+                                        $(this)
+                                            .children()
+                                            .last()
+                                            .append(
+                                                '<a class="pull-right btn-group-hover" href="#/" ' +
+                                                    'onclick="trash($(this).parents(\'tr\'));">' +
+                                                    '<span class="glyphicon glyphicon-trash"></span></a>'
+                                            )
+                                            .find('a')
+                                            .fadeTo('fast', 1);
                                 });
                             },
-                            mouseleave: function(){
+                            mouseleave: function () {
                                 var doomed = $(this);
-                                if ( $('#btntrashmodeup').hasClass('active') )
-                                    doomed = $("#salamisandwich > tbody > tr:lt(" + ($(this).index() + 1) + ")");
-                                if ( $('#btntrashmodedown').hasClass('active') )
-                                    doomed = $("#salamisandwich > tbody > tr:gt(" + ($(this).index() - 1) + ")");
-                                $.each(doomed, function(){$(this).children().last().find("a").stop().remove();});
-                            }
+                                if ($('#btntrashmodeup').hasClass('active'))
+                                    doomed = $(
+                                        '#salamisandwich > tbody > tr:lt(' +
+                                            ($(this).index() + 1) +
+                                            ')'
+                                    );
+                                if ($('#btntrashmodedown').hasClass('active'))
+                                    doomed = $(
+                                        '#salamisandwich > tbody > tr:gt(' +
+                                            ($(this).index() - 1) +
+                                            ')'
+                                    );
+                                $.each(doomed, function () {
+                                    $(this)
+                                        .children()
+                                        .last()
+                                        .find('a')
+                                        .stop()
+                                        .remove();
+                                });
+                            },
                         });
-                    };
+                    }
 
                     $('#salamisandwich > tbody > tr').on({
-                        click: function() {
-                            $('#salamisandwich > tbody > tr').removeClass('active');
-                            socket.send('MPD_API_PLAY_TRACK,'+$(this).attr('trackid'));
+                        click: function () {
+                            $('#salamisandwich > tbody > tr').removeClass(
+                                'active'
+                            );
+                            socket.send(
+                                'MPD_API_PLAY_TRACK,' + $(this).attr('trackid')
+                            );
                             $(this).addClass('active');
                         },
                     });
                     //Helper function to keep table row from collapsing when being sorted
-                    var fixHelperModified = function(e, tr) {
-                      var $originals = tr.children();
-                      var $helper = tr.clone();
-                      $helper.children().each(function(index)
-                      {
-                        $(this).width($originals.eq(index).width())
-                      });
-                      return $helper;
+                    var fixHelperModified = function (e, tr) {
+                        var $originals = tr.children();
+                        var $helper = tr.clone();
+                        $helper.children().each(function (index) {
+                            $(this).width($originals.eq(index).width());
+                        });
+                        return $helper;
                     };
-                    
+
                     //Make queue table sortable
-                    $('#salamisandwich > tbody').sortable({
-                      helper: fixHelperModified,
-                      stop: function(event,ui) {renumber_table('#salamisandwich',ui.item)}
-                    }).disableSelection();
+                    $('#salamisandwich > tbody')
+                        .sortable({
+                            helper: fixHelperModified,
+                            stop: function (event, ui) {
+                                renumber_table('#salamisandwich', ui.item);
+                            },
+                        })
+                        .disableSelection();
                     break;
                 case 'search':
                     $('#wait').modal('hide');
                 case 'browse':
-                    if(current_app !== 'browse' && current_app !== 'search')
+                    if (current_app !== 'browse' && current_app !== 'search')
                         break;
 
                     /* The use of encodeURI() below might seem useless, but it's not. It prevents
@@ -333,304 +445,463 @@ function webSocketConnect() {
                         $('#salamisandwich > tbody').sortable('destroy');
                     }
                     for (var item in obj.data) {
-                        switch(obj.data[item].type) {
+                        switch (obj.data[item].type) {
                             case 'directory':
                                 var clazz = 'dir';
-                                if (filter !== "") {
+                                if (filter !== '') {
                                     var first = basename(obj.data[item].dir)[0];
-                                    if (filter === "num" && isNaN(first)) {
+                                    if (filter === 'num' && isNaN(first)) {
                                         clazz += ' hide';
-                                    } else if (filter >= "A" && filter <= "Z" && first.toUpperCase() !== filter) {
+                                    } else if (
+                                        filter >= 'A' &&
+                                        filter <= 'Z' &&
+                                        first.toUpperCase() !== filter
+                                    ) {
                                         clazz += ' hide';
-                                    } else if (filter === "plist") {
+                                    } else if (filter === 'plist') {
                                         clazz += ' hide';
                                     }
                                 }
                                 $('#salamisandwich > tbody').append(
-                                    "<tr uri=\"" + encodeURI(obj.data[item].dir) + "\" class=\"" + clazz + "\">" +
-                                    "<td><span class=\"glyphicon glyphicon-folder-open\"></span></td>" +
-                                    "<td colspan=\"3\"><a>" + basename(obj.data[item].dir) + "</a></td>" +
-                                    "<td></td><td></td></tr>"
+                                    '<tr uri="' +
+                                        encodeURI(obj.data[item].dir) +
+                                        '" class="' +
+                                        clazz +
+                                        '">' +
+                                        '<td><span class="glyphicon glyphicon-folder-open"></span></td>' +
+                                        '<td colspan="3"><a>' +
+                                        basename(obj.data[item].dir) +
+                                        '</a></td>' +
+                                        '<td></td><td></td></tr>'
                                 );
                                 break;
                             case 'playlist':
                                 var clazz = 'plist';
-                                if ( (filter !== "") && (filter !== "plist") ) {
+                                if (filter !== '' && filter !== 'plist') {
                                     clazz += ' hide';
                                 }
                                 $('#salamisandwich > tbody').append(
-                                    "<tr uri=\"" + encodeURI(obj.data[item].plist) + "\" class=\"" + clazz + "\">" +
-                                    "<td><span class=\"glyphicon glyphicon-list\"></span></td>" +
-                                    "<td colspan=\"3\"><a>" + basename(obj.data[item].plist) + "</a></td>" +
-                                    "<td></td><td></td></tr>"
+                                    '<tr uri="' +
+                                        encodeURI(obj.data[item].plist) +
+                                        '" class="' +
+                                        clazz +
+                                        '">' +
+                                        '<td><span class="glyphicon glyphicon-list"></span></td>' +
+                                        '<td colspan="3"><a>' +
+                                        basename(obj.data[item].plist) +
+                                        '</a></td>' +
+                                        '<td></td><td></td></tr>'
                                 );
                                 break;
                             case 'song':
-                                var minutes = Math.floor(obj.data[item].duration / 60);
-                                var seconds = obj.data[item].duration - minutes * 60;
+                                var minutes = Math.floor(
+                                    obj.data[item].duration / 60
+                                );
+                                var seconds =
+                                    obj.data[item].duration - minutes * 60;
 
                                 if (obj.data[item].artist == null) {
-                                    var artist = "<td colspan=\"2\">";
+                                    var artist = '<td colspan="2">';
                                 } else {
-                                    var artist = "<td>" + obj.data[item].artist +
-                                                     "<span>" + obj.data[item].album + "</span></td><td>";
+                                    var artist =
+                                        '<td>' +
+                                        obj.data[item].artist +
+                                        '<span>' +
+                                        obj.data[item].album +
+                                        '</span></td><td>';
                                 }
 
                                 $('#salamisandwich > tbody').append(
-                                    "<tr uri=\"" + encodeURI(obj.data[item].uri) + "\" class=\"song\">" +
-                                    "<td><span class=\"glyphicon glyphicon-music\"></span></td>" + 
-                                    "<td>" + obj.data[item].artist + "</td>" + 
-                                    "<td>" + obj.data[item].album  + "</td>" +
-                                    "<td>" + obj.data[item].title  + "</td>" +
-                                    "<td>" + minutes + ":" + (seconds < 10 ? '0' : '') + seconds +
-                                    "</td><td></td></tr>"
+                                    '<tr uri="' +
+                                        encodeURI(obj.data[item].uri) +
+                                        '" class="song">' +
+                                        '<td><span class="glyphicon glyphicon-music"></span></td>' +
+                                        '<td>' +
+                                        obj.data[item].artist +
+                                        '</td>' +
+                                        '<td>' +
+                                        obj.data[item].album +
+                                        '</td>' +
+                                        '<td>' +
+                                        obj.data[item].title +
+                                        '</td>' +
+                                        '<td>' +
+                                        minutes +
+                                        ':' +
+                                        (seconds < 10 ? '0' : '') +
+                                        seconds +
+                                        '</td><td></td></tr>'
                                 );
                                 break;
                             case 'wrap':
-                                if(current_app == 'browse') {
+                                if (current_app == 'browse') {
                                     $('#next').removeClass('hide');
                                 } else {
                                     $('#salamisandwich > tbody').append(
-                                        "<tr><td><span class=\"glyphicon glyphicon-remove\"></span></td>" +
-                                        "<td colspan=\"3\">Too many results, please refine your search!</td>" +
-                                        "<td></td><td></td></tr>"
+                                        '<tr><td><span class="glyphicon glyphicon-remove"></span></td>' +
+                                            '<td colspan="3">Too many results, please refine your search!</td>' +
+                                            '<td></td><td></td></tr>'
                                     );
                                 }
                                 break;
                         }
 
-                        if(pagination > 0)
-                            $('#prev').removeClass('hide');
-
+                        if (pagination > 0) $('#prev').removeClass('hide');
                     }
 
-                    function appendClickableIcon(appendTo, onClickAction, glyphicon) {
-                        $(appendTo).append(
-                            "<a role=\"button\" class=\"pull-right btn-group-hover\">" +
-                            "<span class=\"glyphicon glyphicon-" + glyphicon + "\"></span></a>")
-                            .find('a').click(function(e) {
+                    function appendClickableIcon(
+                        appendTo,
+                        onClickAction,
+                        glyphicon
+                    ) {
+                        $(appendTo)
+                            .append(
+                                '<a role="button" class="pull-right btn-group-hover">' +
+                                    '<span class="glyphicon glyphicon-' +
+                                    glyphicon +
+                                    '"></span></a>'
+                            )
+                            .find('a')
+                            .click(function (e) {
                                 e.stopPropagation();
-                                socket.send(onClickAction + "," + decodeURI($(this).parents("tr").attr("uri")));
-                            $('.top-right').notify({
-                                message:{
-                                    text: "\"" + $('td:nth-last-child(3)', $(this).parents("tr")).text() + "\" added"
-                                } }).show();
-                            }).fadeTo('fast',1);
+                                socket.send(
+                                    onClickAction +
+                                        ',' +
+                                        decodeURI(
+                                            $(this).parents('tr').attr('uri')
+                                        )
+                                );
+                                $('.top-right')
+                                    .notify({
+                                        message: {
+                                            text:
+                                                '"' +
+                                                $(
+                                                    'td:nth-last-child(3)',
+                                                    $(this).parents('tr')
+                                                ).text() +
+                                                '" added',
+                                        },
+                                    })
+                                    .show();
+                            })
+                            .fadeTo('fast', 1);
                     }
 
-                    if ( isTouch ) {
-                        appendClickableIcon($("#salamisandwich > tbody > tr.dir > td:last-child"), 'MPD_API_ADD_TRACK', 'plus');
-                        appendClickableIcon($("#salamisandwich > tbody > tr.song > td:last-child"), 'MPD_API_ADD_TRACK', 'play');
+                    if (isTouch) {
+                        appendClickableIcon(
+                            $(
+                                '#salamisandwich > tbody > tr.dir > td:last-child'
+                            ),
+                            'MPD_API_ADD_TRACK',
+                            'plus'
+                        );
+                        appendClickableIcon(
+                            $(
+                                '#salamisandwich > tbody > tr.song > td:last-child'
+                            ),
+                            'MPD_API_ADD_TRACK',
+                            'play'
+                        );
                     } else {
                         $('#salamisandwich > tbody > tr').on({
-                            mouseenter: function() {
-                                if($(this).is(".dir")) 
-                                    appendClickableIcon($(this).children().last(), 'MPD_API_ADD_TRACK', 'plus');
-                                else if($(this).is(".song"))
-                                    appendClickableIcon($(this).children().last(), 'MPD_API_ADD_PLAY_TRACK', 'play');
+                            mouseenter: function () {
+                                if ($(this).is('.dir'))
+                                    appendClickableIcon(
+                                        $(this).children().last(),
+                                        'MPD_API_ADD_TRACK',
+                                        'plus'
+                                    );
+                                else if ($(this).is('.song'))
+                                    appendClickableIcon(
+                                        $(this).children().last(),
+                                        'MPD_API_ADD_PLAY_TRACK',
+                                        'play'
+                                    );
                             },
-                            mouseleave: function(){
-                                $(this).children().last().find("a").stop().remove();
-                            }
+                            mouseleave: function () {
+                                $(this)
+                                    .children()
+                                    .last()
+                                    .find('a')
+                                    .stop()
+                                    .remove();
+                            },
                         });
-                    };
+                    }
                     $('#salamisandwich > tbody > tr').on({
-                        click: function() {
-                            switch($(this).attr('class')) {
+                        click: function () {
+                            switch ($(this).attr('class')) {
                                 case 'dir':
                                     pagination = 0;
-                                    browsepath = $(this).attr("uri");
-                                    $("#browse > a").attr("href", '#/browse/'+pagination+'/'+browsepath);
-									$('#filter > a').attr("href", '#/browse/'+pagination+'/'+browsepath);
-                                    app.setLocation('#/browse/'+pagination+'/'+browsepath);
-									set_filter('');
+                                    browsepath = $(this).attr('uri');
+                                    $('#browse > a').attr(
+                                        'href',
+                                        '#/browse/' +
+                                            pagination +
+                                            '/' +
+                                            browsepath
+                                    );
+                                    $('#filter > a').attr(
+                                        'href',
+                                        '#/browse/' +
+                                            pagination +
+                                            '/' +
+                                            browsepath
+                                    );
+                                    app.setLocation(
+                                        '#/browse/' +
+                                            pagination +
+                                            '/' +
+                                            browsepath
+                                    );
+                                    set_filter('');
                                     break;
                                 case 'song':
-                                    socket.send("MPD_API_ADD_TRACK," + decodeURI($(this).attr("uri")));
-                                    $('.top-right').notify({
-                                        message:{
-                                            text: "\"" + $('td:nth-last-child(3)', this).text() + "\" added"
-                                        }
-                                    }).show();
+                                    socket.send(
+                                        'MPD_API_ADD_TRACK,' +
+                                            decodeURI($(this).attr('uri'))
+                                    );
+                                    $('.top-right')
+                                        .notify({
+                                            message: {
+                                                text:
+                                                    '"' +
+                                                    $(
+                                                        'td:nth-last-child(3)',
+                                                        this
+                                                    ).text() +
+                                                    '" added',
+                                            },
+                                        })
+                                        .show();
                                     break;
                                 case 'plist':
-                                    socket.send("MPD_API_ADD_PLAYLIST," + decodeURI($(this).attr("uri")));
-                                    $('.top-right').notify({
-                                        message:{
-                                            text: "\"" + $('td:nth-last-child(3)', this).text() + "\" added"
-                                        }
-                                    }).show();
+                                    socket.send(
+                                        'MPD_API_ADD_PLAYLIST,' +
+                                            decodeURI($(this).attr('uri'))
+                                    );
+                                    $('.top-right')
+                                        .notify({
+                                            message: {
+                                                text:
+                                                    '"' +
+                                                    $(
+                                                        'td:nth-last-child(3)',
+                                                        this
+                                                    ).text() +
+                                                    '" added',
+                                            },
+                                        })
+                                        .show();
                                     break;
                             }
-                        }
+                        },
                     });
 
-					$('#breadcrump > li > a').on({
-						click: function() {
-							pagination = 0;
-							browsepath = $(this).attr("uri");
-							$("#browse > a").attr("href", '#/browse/'+pagination+'/'+browsepath);
-							$('#filter > a').attr("href", '#/browse/'+pagination+'/'+browsepath);
-							app.setLocation('#/browse/'+pagination+'/'+browsepath);
-							set_filter('');
-						}
-					});
+                    $('#breadcrump > li > a').on({
+                        click: function () {
+                            pagination = 0;
+                            browsepath = $(this).attr('uri');
+                            $('#browse > a').attr(
+                                'href',
+                                '#/browse/' + pagination + '/' + browsepath
+                            );
+                            $('#filter > a').attr(
+                                'href',
+                                '#/browse/' + pagination + '/' + browsepath
+                            );
+                            app.setLocation(
+                                '#/browse/' + pagination + '/' + browsepath
+                            );
+                            set_filter('');
+                        },
+                    });
 
                     break;
                 case 'state':
                     updatePlayIcon(obj.data.state);
                     updateVolumeIcon(obj.data.volume);
 
-                    if(JSON.stringify(obj) === JSON.stringify(last_state))
+                    if (JSON.stringify(obj) === JSON.stringify(last_state))
                         break;
 
-                    current_song.totalTime  = obj.data.totalTime;
+                    current_song.totalTime = obj.data.totalTime;
                     current_song.currentSongId = obj.data.currentsongid;
                     var total_minutes = Math.floor(obj.data.totalTime / 60);
                     var total_seconds = obj.data.totalTime - total_minutes * 60;
 
                     var elapsed_minutes = Math.floor(obj.data.elapsedTime / 60);
-                    var elapsed_seconds = obj.data.elapsedTime - elapsed_minutes * 60;
+                    var elapsed_seconds =
+                        obj.data.elapsedTime - elapsed_minutes * 60;
 
                     $('#volumeslider').slider(obj.data.volume);
-                    var progress = Math.floor(100*obj.data.elapsedTime/obj.data.totalTime);
+                    var progress = Math.floor(
+                        (100 * obj.data.elapsedTime) / obj.data.totalTime
+                    );
                     $('#progressbar').slider(progress);
 
-                    $('#counter')
-                    .text(elapsed_minutes + ":" + 
-                        (elapsed_seconds < 10 ? '0' : '') + elapsed_seconds + " / " +
-                        total_minutes + ":" + (total_seconds < 10 ? '0' : '') + total_seconds);
+                    $('#counter').text(
+                        elapsed_minutes +
+                            ':' +
+                            (elapsed_seconds < 10 ? '0' : '') +
+                            elapsed_seconds +
+                            ' / ' +
+                            total_minutes +
+                            ':' +
+                            (total_seconds < 10 ? '0' : '') +
+                            total_seconds
+                    );
 
-                    $('#salamisandwich > tbody > tr').removeClass('active').css("font-weight", "");
-                    $('#salamisandwich > tbody > tr[trackid='+obj.data.currentsongid+']').addClass('active').css("font-weight", "bold");
+                    $('#salamisandwich > tbody > tr')
+                        .removeClass('active')
+                        .css('font-weight', '');
+                    $(
+                        '#salamisandwich > tbody > tr[trackid=' +
+                            obj.data.currentsongid +
+                            ']'
+                    )
+                        .addClass('active')
+                        .css('font-weight', 'bold');
 
-                    if(obj.data.random)
-                        $('#btnrandom').addClass("active")
-                    else
-                        $('#btnrandom').removeClass("active");
+                    if (obj.data.random) $('#btnrandom').addClass('active');
+                    else $('#btnrandom').removeClass('active');
 
-                    if(obj.data.consume)
-                        $('#btnconsume').addClass("active")
-                    else
-                        $('#btnconsume').removeClass("active");
+                    if (obj.data.consume) $('#btnconsume').addClass('active');
+                    else $('#btnconsume').removeClass('active');
 
-                    if(obj.data.single)
-                        $('#btnsingle').addClass("active")
-                    else
-                        $('#btnsingle').removeClass("active");
+                    if (obj.data.single) $('#btnsingle').addClass('active');
+                    else $('#btnsingle').removeClass('active');
 
-                    if(obj.data.crossfade)
-                        $('#btncrossfade').addClass("active")
-                    else
-                        $('#btncrossfade').removeClass("active");
+                    if (obj.data.crossfade)
+                        $('#btncrossfade').addClass('active');
+                    else $('#btncrossfade').removeClass('active');
 
-                    if(obj.data.repeat)
-                        $('#btnrepeat').addClass("active")
-                    else
-                        $('#btnrepeat').removeClass("active");
+                    if (obj.data.repeat) $('#btnrepeat').addClass('active');
+                    else $('#btnrepeat').removeClass('active');
 
                     last_state = obj;
                     break;
                 case 'outputnames':
                     $('#btn-outputs-block button').remove();
-                    if ( Object.keys(obj.data).length ) {
-		        $.each(obj.data, function(id, name){
-                            var btn = $('<button id="btnoutput'+id+'" class="btn btn-default" onclick="toggleoutput(this, '+id+')"><span class="glyphicon glyphicon-volume-up"></span> '+name+'</button>');
+                    if (Object.keys(obj.data).length) {
+                        $.each(obj.data, function (id, name) {
+                            var btn = $(
+                                '<button id="btnoutput' +
+                                    id +
+                                    '" class="btn btn-default" onclick="toggleoutput(this, ' +
+                                    id +
+                                    ')"><span class="glyphicon glyphicon-volume-up"></span> ' +
+                                    name +
+                                    '</button>'
+                            );
                             btn.appendTo($('#btn-outputs-block'));
                         });
-		    } else {
+                    } else {
                         $('#btn-outputs-block').addClass('hide');
-		    }
+                    }
                     /* remove cache, since the buttons have been recreated */
                     last_outputs = '';
                     break;
                 case 'outputs':
-                    if(JSON.stringify(obj) === JSON.stringify(last_outputs))
+                    if (JSON.stringify(obj) === JSON.stringify(last_outputs))
                         break;
-                    $.each(obj.data, function(id, enabled){
-                        if (enabled)
-                        $('#btnoutput'+id).addClass("active");
-                        else
-                        $('#btnoutput'+id).removeClass("active");
+                    $.each(obj.data, function (id, enabled) {
+                        if (enabled) $('#btnoutput' + id).addClass('active');
+                        else $('#btnoutput' + id).removeClass('active');
                     });
                     last_outputs = obj;
                     break;
                 case 'disconnected':
-                    if($('.top-right').has('div').length == 0)
-                        $('.top-right').notify({
-                            message:{text:"ympd lost connection to MPD "},
-                            type: "danger",
-                            fadeOut: { enabled: true, delay: 1000 },
-                        }).show();
+                    if ($('.top-right').has('div').length == 0)
+                        $('.top-right')
+                            .notify({
+                                message: {
+                                    text: 'ympd lost connection to MPD ',
+                                },
+                                type: 'danger',
+                                fadeOut: { enabled: true, delay: 1000 },
+                            })
+                            .show();
                     break;
                 case 'update_queue':
-                    if(current_app === 'queue')
-                        socket.send('MPD_API_GET_QUEUE,'+pagination);
+                    if (current_app === 'queue')
+                        socket.send('MPD_API_GET_QUEUE,' + pagination);
                     break;
                 case 'song_change':
                     updatePageTitle(obj.data);
-                    $('#album').text("");
-                    $('#artist').text("");
+                    $('#album').text('');
+                    $('#artist').text('');
 
-					$('#btnlove').removeClass("active");
+                    $('#btnlove').removeClass('active');
 
-                    $('#currenttrack').text(" " + obj.data.title);
-                    var notification = "<strong><h4>" + obj.data.title + "</h4></strong>";
+                    $('#currenttrack').text(' ' + obj.data.title);
+                    var notification =
+                        '<strong><h4>' + obj.data.title + '</h4></strong>';
 
-                    if(obj.data.artist) {
+                    if (obj.data.artist) {
                         $('#artist').text(obj.data.artist);
-                        notification += obj.data.artist + "<br />";
+                        notification += obj.data.artist + '<br />';
                     }
-                    if(obj.data.album) {
+                    if (obj.data.album) {
                         $('#album').text(obj.data.album);
-                        notification += obj.data.album + "<br />";
+                        notification += obj.data.album + '<br />';
                     }
 
-                    if ($.cookie("notification") === "true")
-                        songNotify(obj.data.title, obj.data.artist, obj.data.album );
+                    if ($.cookie('notification') === 'true')
+                        songNotify(
+                            obj.data.title,
+                            obj.data.artist,
+                            obj.data.album
+                        );
                     else
-                        $('.top-right').notify({
-                            message:{html: notification},
-                            type: "info",
-                        }).show();        
+                        $('.top-right')
+                            .notify({
+                                message: { html: notification },
+                                type: 'info',
+                            })
+                            .show();
                     break;
                 case 'mpdhost':
                     $('#mpdhost').val(obj.data.host);
                     setLocalStream(obj.data.host);
                     $('#mpdport').val(obj.data.port);
-                    if(obj.data.passwort_set)
+                    if (obj.data.passwort_set)
                         $('#mpd_password_set').removeClass('hide');
                     break;
-                
+
                 case 'error':
-                    $('.top-right').notify({
-                        message:{text: obj.data},
-                        type: "danger",
-                    }).show();
+                    $('.top-right')
+                        .notify({
+                            message: { text: obj.data },
+                            type: 'danger',
+                        })
+                        .show();
                 default:
                     break;
             }
-        }
+        };
 
-        socket.onclose = function(){
-            console.log("disconnected");
-            $('.top-right').notify({
-                message:{text:"Connection to ympd lost, retrying in 3 seconds "},
-                type: "danger", 
-                onClose: function () {
-                    webSocketConnect();
-                }
-            }).show();
-        }
-
-    } catch(exception) {
+        socket.onclose = function () {
+            console.log('disconnected');
+            $('.top-right')
+                .notify({
+                    message: {
+                        text: 'Connection to ympd lost, retrying in 3 seconds ',
+                    },
+                    type: 'danger',
+                    onClose: function () {
+                        webSocketConnect();
+                    },
+                })
+                .show();
+        };
+    } catch (exception) {
         alert('<p>Error' + exception);
     }
-
 }
 
-function get_appropriate_ws_url()
-{
+function get_appropriate_ws_url() {
     var pcol;
     var u = document.URL;
     var separator;
@@ -640,115 +911,122 @@ function get_appropriate_ws_url()
     /* https:// url itself, otherwise unencrypted
     /*/
 
-    if (u.substring(0, 5) == "https") {
-        pcol = "wss://";
+    if (u.substring(0, 5) == 'https') {
+        pcol = 'wss://';
         u = u.substr(8);
     } else {
-        pcol = "ws://";
-        if (u.substring(0, 4) == "http")
-            u = u.substr(7);
+        pcol = 'ws://';
+        if (u.substring(0, 4) == 'http') u = u.substr(7);
     }
 
     u = u.split('#');
 
     if (/\/$/.test(u[0])) {
-        separator = "";
+        separator = '';
     } else {
-        separator = "/";
+        separator = '/';
     }
 
-    return pcol + u[0] + separator + "ws";
+    return pcol + u[0] + separator + 'ws';
 }
 
-var updateVolumeIcon = function(volume)
-{
-    $("#volume-icon").removeClass("glyphicon-volume-off");
-    $("#volume-icon").removeClass("glyphicon-volume-up");
-    $("#volume-icon").removeClass("glyphicon-volume-down");
+var updateVolumeIcon = function (volume) {
+    $('#volume-icon').removeClass('glyphicon-volume-off');
+    $('#volume-icon').removeClass('glyphicon-volume-up');
+    $('#volume-icon').removeClass('glyphicon-volume-down');
 
-    if(volume == 0) {
-        $("#volume-icon").addClass("glyphicon-volume-off");
+    if (volume == 0) {
+        $('#volume-icon').addClass('glyphicon-volume-off');
     } else if (volume < 50) {
-        $("#volume-icon").addClass("glyphicon-volume-down");
+        $('#volume-icon').addClass('glyphicon-volume-down');
     } else {
-        $("#volume-icon").addClass("glyphicon-volume-up");
+        $('#volume-icon').addClass('glyphicon-volume-up');
     }
-}
+};
 
-var updatePlayIcon = function(state)
-{
-    $("#play-icon").removeClass("glyphicon-play")
-    .removeClass("glyphicon-pause");
-    $('#track-icon').removeClass("glyphicon-play")
-    .removeClass("glyphicon-pause")
-    .removeClass("glyphicon-stop");
+var updatePlayIcon = function (state) {
+    $('#play-icon')
+        .removeClass('glyphicon-play')
+        .removeClass('glyphicon-pause');
+    $('#track-icon')
+        .removeClass('glyphicon-play')
+        .removeClass('glyphicon-pause')
+        .removeClass('glyphicon-stop');
 
-    if(state == 1) { // stop
-        $("#play-icon").addClass("glyphicon-play");
-        $('#track-icon').addClass("glyphicon-stop");
-		document.getElementById('player').pause();
-    } else if(state == 2) { // play
-        $("#play-icon").addClass("glyphicon-pause");
-        $('#track-icon').addClass("glyphicon-play");
-        if ( ($.cookie("autoplay") === "true") && (player.paused) ) {
-			clickLocalPlay();
-		}
-    } else { // pause
-        $("#play-icon").addClass("glyphicon-play");
-        $('#track-icon').addClass("glyphicon-pause");
-		document.getElementById('player').pause();
+    if (state == 1) {
+        // stop
+        $('#play-icon').addClass('glyphicon-play');
+        $('#track-icon').addClass('glyphicon-stop');
+        document.getElementById('player').pause();
+    } else if (state == 2) {
+        // play
+        $('#play-icon').addClass('glyphicon-pause');
+        $('#track-icon').addClass('glyphicon-play');
+        if ($.cookie('autoplay') === 'true' && player.paused) {
+            clickLocalPlay();
+        }
+    } else {
+        // pause
+        $('#play-icon').addClass('glyphicon-play');
+        $('#track-icon').addClass('glyphicon-pause');
+        document.getElementById('player').pause();
     }
-}
+};
 
-var updatePageTitle = function(songInfo) {
-    if(!songInfo || (!songInfo.artist && !songInfo.title)) {
+var updatePageTitle = function (songInfo) {
+    if (!songInfo || (!songInfo.artist && !songInfo.title)) {
         document.title = 'ympd';
         return;
     }
-    if(songInfo.artist) {
-        if(songInfo.title) {
+    if (songInfo.artist) {
+        if (songInfo.title) {
             document.title = songInfo.artist + ' - ' + songInfo.title;
         }
     } else {
         document.title = songInfo.title;
     }
-}
+};
 
 function updateDB() {
     socket.send('MPD_API_UPDATE_DB');
-    $('.top-right').notify({
-        message:{text:"Updating MPD Database... "}
-    }).show();
+    $('.top-right')
+        .notify({
+            message: { text: 'Updating MPD Database... ' },
+        })
+        .show();
 }
 
 function clickPlay() {
-    if($('#track-icon').hasClass('glyphicon-stop'))
+    if ($('#track-icon').hasClass('glyphicon-stop'))
         socket.send('MPD_API_SET_PLAY');
-    else
-        socket.send('MPD_API_SET_PAUSE');
+    else socket.send('MPD_API_SET_PAUSE');
 }
 
 function clickLocalPlay() {
     var player = document.getElementById('player');
-    $("#localplay-icon").removeClass("glyphicon-play").removeClass("glyphicon-pause");
-	
+    $('#localplay-icon')
+        .removeClass('glyphicon-play')
+        .removeClass('glyphicon-pause');
 
-    if ( !$('#track-icon').hasClass('glyphicon-play') ) {
-		clickPlay();
-	}
+    if (!$('#track-icon').hasClass('glyphicon-play')) {
+        clickPlay();
+    }
 
-    if ( player.paused ) {
-        var mpdstream = $.cookie("mpdstream");
+    if (player.paused) {
+        var mpdstream = $.cookie('mpdstream');
 
-        if ( mpdstream ) {
+        if (mpdstream) {
             player.src = mpdstream;
-            console.log("playing mpd stream: " + player.src);
+            console.log('playing mpd stream: ' + player.src);
             player.load();
             player.play();
-            $("#localplay-icon").addClass("glyphicon-pause");
+            $('#localplay-icon').addClass('glyphicon-pause');
         } else {
-            $("#mpdstream").change(function(){ clickLocalPlay(); $(this).unbind("change"); });
-            $("#localplay-icon").addClass("glyphicon-play");
+            $('#mpdstream').change(function () {
+                clickLocalPlay();
+                $(this).unbind('change');
+            });
+            $('#localplay-icon').addClass('glyphicon-play');
             getHost();
         }
     } else {
@@ -757,43 +1035,41 @@ function clickLocalPlay() {
 }
 
 function setLocalStream(mpdhost) {
-    var mpdstream = $.cookie("mpdstream");
+    var mpdstream = $.cookie('mpdstream');
 
-    if ( !mpdstream ) {
-        mpdstream = "http://";
-        if ( mpdhost == "127.0.0.1" )
-            mpdstream += window.location.hostname;
-        else
-            mpdstream += mpdhost;
-        mpdstream += ":8000/";
+    if (!mpdstream) {
+        mpdstream = 'http://';
+        if (mpdhost == '127.0.0.1') mpdstream += window.location.hostname;
+        else mpdstream += mpdhost;
+        mpdstream += ':8000/';
 
-        $.cookie("mpdstream", mpdstream, { expires: 424242 });
+        $.cookie('mpdstream', mpdstream, { expires: 424242 });
     }
 
-    $("#mpdstream").val(mpdstream);
-    $("#mpdstream").change();
+    $('#mpdstream').val(mpdstream);
+    $('#mpdstream').change();
 }
 
 function trash(tr) {
-    if ( $('#btntrashmodeup').hasClass('active') ) {
+    if ($('#btntrashmodeup').hasClass('active')) {
         socket.send('MPD_API_RM_RANGE,0,' + (tr.index() + 1));
         tr.remove();
-    } else if ( $('#btntrashmodesingle').hasClass('active') ) {
+    } else if ($('#btntrashmodesingle').hasClass('active')) {
         socket.send('MPD_API_RM_TRACK,' + tr.attr('trackid'));
         tr.remove();
-    } else if ( $('#btntrashmodedown').hasClass('active') ) {
+    } else if ($('#btntrashmodedown').hasClass('active')) {
         socket.send('MPD_API_RM_RANGE,' + tr.index() + ',-1');
         tr.remove();
-    };
+    }
 }
 
-function renumber_table(tableID,item) {
-    was = item.children("td").first().text();//Check if first item exists!
-    is = item.index() + 1;//maybe add pagination
+function renumber_table(tableID, item) {
+    was = item.children('td').first().text(); //Check if first item exists!
+    is = item.index() + 1; //maybe add pagination
 
     if (was != is) {
-        socket.send("MPD_API_MOVE_TRACK," + was + "," + is);
-        socket.send('MPD_API_GET_QUEUE,'+pagination);
+        socket.send('MPD_API_MOVE_TRACK,' + was + ',' + is);
+        socket.send('MPD_API_GET_QUEUE,' + pagination);
     }
 }
 
@@ -802,63 +1078,79 @@ function basename(path) {
 }
 
 function clickLove() {
-    socket.send("MPD_API_SEND_MESSAGE,mpdas," + ($('#btnlove').hasClass('active') ? "unlove" : "love"));
-	if ( $('#btnlove').hasClass('active') )
-		$('#btnlove').removeClass("active");
-	else
-		$('#btnlove').addClass("active");
+    socket.send(
+        'MPD_API_SEND_MESSAGE,mpdas,' +
+            ($('#btnlove').hasClass('active') ? 'unlove' : 'love')
+    );
+    if ($('#btnlove').hasClass('active')) $('#btnlove').removeClass('active');
+    else $('#btnlove').addClass('active');
 }
 
 $('#btnrandom').on('click', function (e) {
-    socket.send("MPD_API_TOGGLE_RANDOM," + ($(this).hasClass('active') ? 0 : 1));
-
+    socket.send(
+        'MPD_API_TOGGLE_RANDOM,' + ($(this).hasClass('active') ? 0 : 1)
+    );
 });
 $('#btnconsume').on('click', function (e) {
-    socket.send("MPD_API_TOGGLE_CONSUME," + ($(this).hasClass('active') ? 0 : 1));
-
+    socket.send(
+        'MPD_API_TOGGLE_CONSUME,' + ($(this).hasClass('active') ? 0 : 1)
+    );
 });
 $('#btnsingle').on('click', function (e) {
-    socket.send("MPD_API_TOGGLE_SINGLE," + ($(this).hasClass('active') ? 0 : 1));
+    socket.send(
+        'MPD_API_TOGGLE_SINGLE,' + ($(this).hasClass('active') ? 0 : 1)
+    );
 });
-$('#btncrossfade').on('click', function(e) {
-    socket.send("MPD_API_TOGGLE_CROSSFADE," + ($(this).hasClass('active') ? 0 : 1));
+$('#btncrossfade').on('click', function (e) {
+    socket.send(
+        'MPD_API_TOGGLE_CROSSFADE,' + ($(this).hasClass('active') ? 0 : 1)
+    );
 });
 $('#btnrepeat').on('click', function (e) {
-    socket.send("MPD_API_TOGGLE_REPEAT," + ($(this).hasClass('active') ? 0 : 1));
+    socket.send(
+        'MPD_API_TOGGLE_REPEAT,' + ($(this).hasClass('active') ? 0 : 1)
+    );
 });
 
 function toggleoutput(button, id) {
-    socket.send("MPD_API_TOGGLE_OUTPUT,"+id+"," + ($(button).hasClass('active') ? 0 : 1));
+    socket.send(
+        'MPD_API_TOGGLE_OUTPUT,' +
+            id +
+            ',' +
+            ($(button).hasClass('active') ? 0 : 1)
+    );
 }
 
-$('#trashmode').children("button").on('click', function(e) {
-    $('#trashmode').children("button").removeClass("active");
-    $(this).addClass("active");
-});
+$('#trashmode')
+    .children('button')
+    .on('click', function (e) {
+        $('#trashmode').children('button').removeClass('active');
+        $(this).addClass('active');
+    });
 
 $('#btnnotify').on('click', function (e) {
-    if($.cookie("notification") === "true") {
-        $.cookie("notification", false);
+    if ($.cookie('notification') === 'true') {
+        $.cookie('notification', false);
     } else {
         Notification.requestPermission(function (permission) {
-            if(!('permission' in Notification)) {
+            if (!('permission' in Notification)) {
                 Notification.permission = permission;
             }
 
-            if (permission === "granted") {
-                $.cookie("notification", true, { expires: 424242 });
-                $('btnnotify').addClass("active");
+            if (permission === 'granted') {
+                $.cookie('notification', true, { expires: 424242 });
+                $('btnnotify').addClass('active');
             }
         });
     }
 });
 
 $('#btnautoplay').on('click', function (e) {
-    if($.cookie("autoplay") === "true") {
-        $.cookie("autoplay", false);
+    if ($.cookie('autoplay') === 'true') {
+        $.cookie('autoplay', false);
     } else {
-        $.cookie("autoplay", true, { expires: 424242 });
-        $('#btnautoplay').addClass("active");
+        $.cookie('autoplay', true, { expires: 424242 });
+        $('#btnautoplay').addClass('active');
     }
 });
 
@@ -866,9 +1158,9 @@ function getHost() {
     socket.send('MPD_API_GET_MPDHOST');
 
     function onEnter(event) {
-      if ( event.which == 13 ) {
-        confirmSettings();
-      }
+        if (event.which == 13) {
+            confirmSettings();
+        }
     }
 
     $('#mpdhost').keypress(onEnter);
@@ -879,79 +1171,77 @@ function getHost() {
 }
 
 $('#search').submit(function () {
-    app.setLocation("#/search/"+$('#search > div > input').val());
+    app.setLocation('#/search/' + $('#search > div > input').val());
     $('#wait').modal('show');
-    setTimeout(function() {
+    setTimeout(function () {
         $('#wait').modal('hide');
     }, 10000);
     return false;
 });
 
 $('.page-btn').on('click', function (e) {
-
     switch ($(this).text()) {
-        case "Next":
+        case 'Next':
             pagination += MAX_ELEMENTS_PER_PAGE;
             break;
-        case "Previous":
+        case 'Previous':
             pagination -= MAX_ELEMENTS_PER_PAGE;
-            if(pagination <= 0)
-                pagination = 0;
+            if (pagination <= 0) pagination = 0;
             break;
     }
 
-    switch(current_app) {
-        case "queue":
-            app.setLocation('#/'+pagination);
+    switch (current_app) {
+        case 'queue':
+            app.setLocation('#/' + pagination);
             break;
-        case "browse":
-            app.setLocation('#/browse/'+pagination+'/'+browsepath);
+        case 'browse':
+            app.setLocation('#/browse/' + pagination + '/' + browsepath);
             break;
     }
     e.preventDefault();
 });
 
 function addStream() {
-    if($('#streamurl').val().length > 0) {
-        socket.send('MPD_API_ADD_TRACK,'+$('#streamurl').val());
+    if ($('#streamurl').val().length > 0) {
+        socket.send('MPD_API_ADD_TRACK,' + $('#streamurl').val());
     }
-    $('#streamurl').val("");
+    $('#streamurl').val('');
     $('#addstream').modal('hide');
 }
 
 function saveQueue() {
-    if($('#playlistname').val().length > 0) {
-        socket.send('MPD_API_SAVE_QUEUE,'+$('#playlistname').val());
+    if ($('#playlistname').val().length > 0) {
+        socket.send('MPD_API_SAVE_QUEUE,' + $('#playlistname').val());
     }
     $('#savequeue').modal('hide');
 }
 
 function confirmSettings() {
-    if($('#mpd_pw').val().length + $('#mpd_pw_con').val().length > 0) {
-        if ($('#mpd_pw').val() !== $('#mpd_pw_con').val())
-        {
+    if ($('#mpd_pw').val().length + $('#mpd_pw_con').val().length > 0) {
+        if ($('#mpd_pw').val() !== $('#mpd_pw_con').val()) {
             $('#mpd_pw_con').popover('show');
-            setTimeout(function() {
+            setTimeout(function () {
                 $('#mpd_pw_con').popover('hide');
             }, 2000);
             return;
-        } else
-            socket.send('MPD_API_SET_MPDPASS,'+$('#mpd_pw').val());
+        } else socket.send('MPD_API_SET_MPDPASS,' + $('#mpd_pw').val());
     }
-    socket.send('MPD_API_SET_MPDHOST,'+$('#mpdport').val()+','+$('#mpdhost').val());
-    $.cookie("mpdstream", $("#mpdstream").val(), { expires: 424242 });
+    socket.send(
+        'MPD_API_SET_MPDHOST,' + $('#mpdport').val() + ',' + $('#mpdhost').val()
+    );
+    $.cookie('mpdstream', $('#mpdstream').val(), { expires: 424242 });
     $('#settings').modal('hide');
 }
 
 $('#mpd_password_set > button').on('click', function (e) {
     socket.send('MPD_API_SET_MPDPASS,');
-    $('#mpd_pw').val("");
-    $('#mpd_pw_con').val("");
+    $('#mpd_pw').val('');
+    $('#mpd_pw_con').val('');
     $('#mpd_password_set').addClass('hide');
-})
+});
 
 function notificationsSupported() {
-    return "Notification" in window;
+    return 'Notification' in window;
 }
 
 function songNotify(title, artist, album) {
@@ -968,19 +1258,26 @@ function songNotify(title, artist, album) {
 */
     //chrome.notifications.create(id, options, creationCallback);
 
-    var textNotification = "";
-    if(typeof artist != 'undefined' && artist.length > 0)
-        textNotification += " " + artist;
-    if(typeof album != 'undefined' && album.length > 0)
-        textNotification += "\n " + album;
+    var textNotification = '';
+    if (typeof artist != 'undefined' && artist.length > 0)
+        textNotification += ' ' + artist;
+    if (typeof album != 'undefined' && album.length > 0)
+        textNotification += '\n ' + album;
 
-    var notification = new Notification(title, {icon: 'assets/favicon.ico', body: textNotification});
-    setTimeout(function(notification) {
-        notification.close();
-    }, 3000, notification);
+    var notification = new Notification(title, {
+        icon: 'assets/favicon.ico',
+        body: textNotification,
+    });
+    setTimeout(
+        function (notification) {
+            notification.close();
+        },
+        3000,
+        notification
+    );
 }
 
-$(document).keydown(function(e){
+$(document).keydown(function (e) {
     if (e.target.tagName == 'INPUT') {
         return;
     }
@@ -1000,52 +1297,82 @@ $(document).keydown(function(e){
     e.preventDefault();
 });
 
-function set_filter (c) {
+function set_filter(c) {
     filter = c;
-	$('#filter > a').removeClass('active');
-	$('#f' + c).addClass('active');
+    $('#filter > a').removeClass('active');
+    $('#f' + c).addClass('active');
 
-    if (filter === "") {
-    	$('#salamisandwich > tbody > tr').removeClass('hide');
-	} else if (filter === "plist") {
-    	$('#salamisandwich > tbody > tr.dir').addClass('hide');
-    	$('#salamisandwich > tbody > tr.song').addClass('hide');
-    	$('#salamisandwich > tbody > tr.plist').removeClass('hide');
+    if (filter === '') {
+        $('#salamisandwich > tbody > tr').removeClass('hide');
+    } else if (filter === 'plist') {
+        $('#salamisandwich > tbody > tr.dir').addClass('hide');
+        $('#salamisandwich > tbody > tr.song').addClass('hide');
+        $('#salamisandwich > tbody > tr.plist').removeClass('hide');
     } else {
-		$.each($('#salamisandwich > tbody > tr'), function(i, line) {
-			var first = basename($(line).attr('uri'))[0];
-			if ( $(line).hasClass('song') ) {
-				first = $(line).children().eq(3).text()[0];
-			}
+        $.each($('#salamisandwich > tbody > tr'), function (i, line) {
+            var first = basename($(line).attr('uri'))[0];
+            if ($(line).hasClass('song')) {
+                first = $(line).children().eq(3).text()[0];
+            }
 
-			if (filter === "num") {
-				if (!isNaN(first)) {
-					$(line).removeClass('hide');
-				} else {
-					$(line).addClass('hide');
-				}
-			} else if (filter >= "A" && filter <= "Z") {
-				if (first.toUpperCase() === filter) {
-					$(line).removeClass('hide');
-				} else {
-					$(line).addClass('hide');
-				}
-			}
-		});
-	}
+            if (filter === 'num') {
+                if (!isNaN(first)) {
+                    $(line).removeClass('hide');
+                } else {
+                    $(line).addClass('hide');
+                }
+            } else if (filter >= 'A' && filter <= 'Z') {
+                if (first.toUpperCase() === filter) {
+                    $(line).removeClass('hide');
+                } else {
+                    $(line).addClass('hide');
+                }
+            }
+        });
+    }
 }
 
-function add_filter () {
-	$('#filter').empty();
-    $('#filter').append('&nbsp;<a onclick="set_filter(\'\')" href="#/browse/'+pagination+'/'+browsepath+'">All</a>');
-    $('#filter').append('&nbsp;<a id="fnum" onclick="set_filter(\'num\')" href="#/browse/'+pagination+'/'+browsepath+'">#</a>');
+function add_filter() {
+    $('#filter').empty();
+    $('#filter').append(
+        '&nbsp;<a onclick="set_filter(\'\')" href="#/browse/' +
+            pagination +
+            '/' +
+            browsepath +
+            '">All</a>'
+    );
+    $('#filter').append(
+        '&nbsp;<a id="fnum" onclick="set_filter(\'num\')" href="#/browse/' +
+            pagination +
+            '/' +
+            browsepath +
+            '">#</a>'
+    );
 
     for (i = 65; i <= 90; i++) {
         var c = String.fromCharCode(i);
-        $('#filter').append('&nbsp;<a id="f' + c + '" onclick="set_filter(\'' + c + '\');" href="#/browse/' + pagination + '/' + browsepath + '">' + c + '</a>');
+        $('#filter').append(
+            '&nbsp;<a id="f' +
+                c +
+                '" onclick="set_filter(\'' +
+                c +
+                '\');" href="#/browse/' +
+                pagination +
+                '/' +
+                browsepath +
+                '">' +
+                c +
+                '</a>'
+        );
     }
 
-    $('#filter').append('&nbsp;<a id="fplist" onclick="set_filter(\'plist\')" href="#/browse/'+pagination+'/'+browsepath+'" class="glyphicon glyphicon-list"></a>');
-	$('#f' + filter).addClass('active');
+    $('#filter').append(
+        '&nbsp;<a id="fplist" onclick="set_filter(\'plist\')" href="#/browse/' +
+            pagination +
+            '/' +
+            browsepath +
+            '" class="glyphicon glyphicon-list"></a>'
+    );
+    $('#f' + filter).addClass('active');
     $('#filter').removeClass('hide');
 }

--- a/htdocs/player.html
+++ b/htdocs/player.html
@@ -1,126 +1,168 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-  <meta charset="utf-8">
-  <meta http-equiv="X-UA-Compatible" content="IE=edge">
-<!--  <meta name="viewport" content="width=device-width, initial-scale=1.0">-->
-  <meta name="viewport" content="width=320">
-  <meta name="description" content="ympd - fast and lightweight MPD webclient">
-  <meta name="author" content="andy@ndyk.de">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <!--  <meta name="viewport" content="width=device-width, initial-scale=1.0">-->
+    <meta name="viewport" content="width=320" />
+    <meta
+      name="description"
+      content="ympd - fast and lightweight MPD webclient"
+    />
+    <meta name="author" content="andy@ndyk.de" />
 
-  <title>ympd player</title>
+    <title>ympd player</title>
 
-  <!-- Bootstrap core CSS -->
-  <link href="css/bootstrap.css" rel="stylesheet">
-  <link href="css/bootstrap-theme.css" rel="stylesheet">
+    <!-- Bootstrap core CSS -->
+    <link href="css/bootstrap.css" rel="stylesheet" />
+    <link href="css/bootstrap-theme.css" rel="stylesheet" />
 
-  <!-- Custom styles for this template -->
-  <link href="css/mpd.css" rel="stylesheet">
-  <link href="assets/favicon.ico" rel="shortcut icon" type="image/vnd.microsoft.icon">
-  <script src="js/jquery-1.10.2.min.js"></script>
-  <script src="js/jquery.cookie.js"></script>
-  <script src="js/bootstrap.min.js"></script>
-  <script src="js/bootstrap-notify.js"></script>
-<script type="text/javascript">
-function clickLocalPlay() {
-    var player = document.getElementById('player');
-    $("#localplay-icon").removeClass("glyphicon-play").removeClass("glyphicon-pause");
+    <!-- Custom styles for this template -->
+    <link href="css/mpd.css" rel="stylesheet" />
+    <link
+      href="assets/favicon.ico"
+      rel="shortcut icon"
+      type="image/vnd.microsoft.icon"
+    />
+    <script src="js/jquery-1.10.2.min.js"></script>
+    <script src="js/jquery.cookie.js"></script>
+    <script src="js/bootstrap.min.js"></script>
+    <script src="js/bootstrap-notify.js"></script>
+    <script type="text/javascript">
+      function clickLocalPlay() {
+        var player = document.getElementById('player');
+        $('#localplay-icon')
+          .removeClass('glyphicon-play')
+          .removeClass('glyphicon-pause');
 
+        if (player.paused) {
+          var mpdstream = $.cookie('mpdstream');
+          player.src = mpdstream;
+          console.log('playing mpd stream: ' + player.src);
+          player.load();
+          player.play();
+          $('#localplay-icon').addClass('glyphicon-pause');
+        } else {
+          player.pause();
+          player.src = '';
+          player.removeAttribute('src');
+          $('#localplay-icon').addClass('glyphicon-play');
+        }
+      }
 
-    if ( player.paused ) {
-        var mpdstream = $.cookie("mpdstream");
-        player.src = mpdstream;
-        console.log("playing mpd stream: " + player.src);
-        player.load();
-        player.play();
-        $("#localplay-icon").addClass("glyphicon-pause");
-    } else {
-        player.pause();
-        player.src='';
-        player.removeAttribute("src");
-        $("#localplay-icon").addClass("glyphicon-play");
-    }
-}
+      $(document).ready(function () {
+        document
+          .getElementById('player')
+          .addEventListener('stalled', function () {
+            if (!document.getElementById('player').paused) {
+              this.pause();
+              clickLocalPlay();
+              $('.top-right')
+                .notify({
+                  message: {
+                    text: 'music stream stalled - trying to recover...',
+                  },
+                  type: 'danger',
+                  fadeOut: { enabled: true, delay: 1000 },
+                })
+                .show();
+            }
+          });
 
-$(document).ready(function(){
-	document.getElementById('player').addEventListener('stalled', function() {
-						if ( !document.getElementById('player').paused ) {
-							this.pause();
-							clickLocalPlay();
-							$('.top-right').notify({
-								message:{text:"music stream stalled - trying to recover..."},
-								type: "danger",
-								fadeOut: { enabled: true, delay: 1000 },
-							}).show();
-						}
-	});
+        document
+          .getElementById('player')
+          .addEventListener('pause', function () {
+            this.src = '';
+            this.removeAttribute('src');
+            $('#localplay-icon')
+              .removeClass('glyphicon-pause')
+              .addClass('glyphicon-play');
+          });
 
-	document.getElementById('player').addEventListener('pause', function() {
-		this.src='';
-		this.removeAttribute("src");
-		$("#localplay-icon").removeClass("glyphicon-pause").addClass("glyphicon-play");
-	});
-
-	document.getElementById('player').addEventListener('error', function failed(e) {
-		this.pause();
-		switch (e.target.error.code) {
-			case e.target.error.MEDIA_ERR_ABORTED:
-				$('.top-right').notify({
-					message:{text:"Audio playback aborted by user."},
-					type: "info",
-					fadeOut: { enabled: true, delay: 1000 },
-				}).show();
-				break;
-			case e.target.error.MEDIA_ERR_NETWORK:
-				$('.top-right').notify({
-					message:{text:"Network error while playing audio."},
-					type: "danger",
-					fadeOut: { enabled: true, delay: 1000 },
-				}).show();
-				break;
-			case e.target.error.MEDIA_ERR_DECODE:
-				$('.top-right').notify({
-					message:{text:"Audio playback aborted. Did you unplug your headphones?"},
-					type: "danger",
-					fadeOut: { enabled: true, delay: 1000 },
-				}).show();
-				break;
-			case e.target.error.MEDIA_ERR_SRC_NOT_SUPPORTED:
-				$('.top-right').notify({
-					message:{text:"Error while loading audio (server, network or format error)."},
-					type: "danger",
-					fadeOut: { enabled: true, delay: 1000 },
-				}).show();
-				break;
-			default:
-				$('.top-right').notify({
-					message:{text:"Unknown error while playing audio."},
-					type: "danger",
-					fadeOut: { enabled: true, delay: 1000 },
-				}).show();
-				break;
-		}
-	}, true);
-});
-</script>
-</head>
-<body>
-  <div class="navbar navbar-inverse navbar-fixed-top" role="navigation">
-    <div class="container">
-        <a class="navbar-brand" href="/" target="_blank"><span class="glyphicon glyphicon-play-circle"></span> ympd</a>
-    </div>
-  </div>
-
-  <div class="container starter-template">
-    <div class="row">
-      <div class="col-md-10 col-xs-12">
-            <audio id="player" preload="none"></audio>
-            <button type="button" class="btn btn-default btn-lg center-block" onclick="clickLocalPlay()">
-              <span id="localplay-icon" class="glyphicon glyphicon-play"></span>
-            </button>
-        <div class="notifications top-right"></div>
+        document.getElementById('player').addEventListener(
+          'error',
+          function failed(e) {
+            this.pause();
+            switch (e.target.error.code) {
+              case e.target.error.MEDIA_ERR_ABORTED:
+                $('.top-right')
+                  .notify({
+                    message: { text: 'Audio playback aborted by user.' },
+                    type: 'info',
+                    fadeOut: { enabled: true, delay: 1000 },
+                  })
+                  .show();
+                break;
+              case e.target.error.MEDIA_ERR_NETWORK:
+                $('.top-right')
+                  .notify({
+                    message: { text: 'Network error while playing audio.' },
+                    type: 'danger',
+                    fadeOut: { enabled: true, delay: 1000 },
+                  })
+                  .show();
+                break;
+              case e.target.error.MEDIA_ERR_DECODE:
+                $('.top-right')
+                  .notify({
+                    message: {
+                      text: 'Audio playback aborted. Did you unplug your headphones?',
+                    },
+                    type: 'danger',
+                    fadeOut: { enabled: true, delay: 1000 },
+                  })
+                  .show();
+                break;
+              case e.target.error.MEDIA_ERR_SRC_NOT_SUPPORTED:
+                $('.top-right')
+                  .notify({
+                    message: {
+                      text: 'Error while loading audio (server, network or format error).',
+                    },
+                    type: 'danger',
+                    fadeOut: { enabled: true, delay: 1000 },
+                  })
+                  .show();
+                break;
+              default:
+                $('.top-right')
+                  .notify({
+                    message: { text: 'Unknown error while playing audio.' },
+                    type: 'danger',
+                    fadeOut: { enabled: true, delay: 1000 },
+                  })
+                  .show();
+                break;
+            }
+          },
+          true
+        );
+      });
+    </script>
+  </head>
+  <body>
+    <div class="navbar navbar-inverse navbar-fixed-top" role="navigation">
+      <div class="container">
+        <a class="navbar-brand" href="/" target="_blank"
+          ><span class="glyphicon glyphicon-play-circle"></span> ympd</a
+        >
       </div>
     </div>
-  </div>
-</body>
+
+    <div class="container starter-template">
+      <div class="row">
+        <div class="col-md-10 col-xs-12">
+          <audio id="player" preload="none"></audio>
+          <button
+            type="button"
+            class="btn btn-default btn-lg center-block"
+            onclick="clickLocalPlay()"
+          >
+            <span id="localplay-icon" class="glyphicon glyphicon-play"></span>
+          </button>
+          <div class="notifications top-right"></div>
+        </div>
+      </div>
+    </div>
+  </body>
 </html>

--- a/src/http_server.c
+++ b/src/http_server.c
@@ -1,7 +1,7 @@
 /* ympd
    (c) 2013-2014 Andrew Karpow <andy@ndyk.de>
    This project's homepage is: http://www.ympd.org
-   
+
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
    the Free Software Foundation; version 2 of the License.
@@ -16,24 +16,22 @@
    Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#include <string.h>
-
 #include "http_server.h"
 
-int callback_http(struct mg_connection *c)
-{
+#include <string.h>
+
+int callback_http(struct mg_connection *c) {
     const struct embedded_file *req_file;
 
-    if(!strcmp(c->uri, "/"))
+    if (!strcmp(c->uri, "/"))
         req_file = find_embedded_file("/index.html");
     else
         req_file = find_embedded_file(c->uri);
 
-    if(req_file)
-    {
+    if (req_file) {
         mg_send_header(c, "Content-Type", req_file->mimetype);
         mg_send_data(c, req_file->data, req_file->size);
-    
+
         return MG_TRUE;
     }
 

--- a/src/http_server.h
+++ b/src/http_server.h
@@ -1,7 +1,7 @@
 /* ympd
    (c) 2013-2014 Andrew Karpow <andy@ndyk.de>
    This project's homepage is: http://www.ympd.org
-   
+
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
    the Free Software Foundation; version 2 of the License.
@@ -22,14 +22,13 @@
 #include "mongoose.h"
 
 struct embedded_file {
-  const char *name;
-  const unsigned char *data;
-  const char *mimetype;
-  size_t size;
+    const char *name;
+    const unsigned char *data;
+    const char *mimetype;
+    size_t size;
 };
 
 const struct embedded_file *find_embedded_file(const char *name);
 int callback_http(struct mg_connection *c);
 
 #endif
-

--- a/src/json_encode.h
+++ b/src/json_encode.h
@@ -1,7 +1,7 @@
 /* ympd
    (c) 2013-2014 Andrew Karpow <andy@ndyk.de>
    This project's homepage is: http://www.ympd.org
-   
+
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
    the Free Software Foundation; version 2 of the License.
@@ -15,7 +15,7 @@
    with this program; if not, write to the Free Software Foundation, Inc.,
    Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
-   
+
 #ifndef __JSON_ENCODE_H__
 #define __JSON_ENCODE_H__
 

--- a/src/mpd_client.c
+++ b/src/mpd_client.c
@@ -1,7 +1,7 @@
 /* ympd
    (c) 2013-2014 Andrew Karpow <andy@ndyk.de>
    This project's homepage is: http://www.ympd.org
-   
+
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
    the Free Software Foundation; version 2 of the License.
@@ -16,15 +16,16 @@
    Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#include <stdio.h>
-#include <string.h>
-#include <unistd.h>
-#include <stdlib.h>
+#include "mpd_client.h"
+
 #include <libgen.h>
 #include <mpd/client.h>
 #include <mpd/message.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
 
-#include "mpd_client.h"
 #include "config.h"
 #include "json_encode.h"
 
@@ -32,44 +33,39 @@
 static int mpd_notify_callback(struct mg_connection *c, enum mg_event ev);
 struct t_mpd mpd;
 
-const char * mpd_cmd_strs[] = {
-    MPD_CMDS(GEN_STR)
-};
+const char *mpd_cmd_strs[] = {MPD_CMDS(GEN_STR)};
 
-char * get_arg1 (char *p) {
-	return strchr(p, ',') + 1;
+char *get_arg1(char *p) {
+    return strchr(p, ',') + 1;
 }
 
-char * get_arg2 (char *p) {
-	return get_arg1(get_arg1(p));
+char *get_arg2(char *p) {
+    return get_arg1(get_arg1(p));
 }
 
-static inline enum mpd_cmd_ids get_cmd_id(char *cmd)
-{
-    for(int i = 0; i < sizeof(mpd_cmd_strs)/sizeof(mpd_cmd_strs[0]); i++)
-        if(!strncmp(cmd, mpd_cmd_strs[i], strlen(mpd_cmd_strs[i])))
+static inline enum mpd_cmd_ids get_cmd_id(char *cmd) {
+    for (int i = 0; i < sizeof(mpd_cmd_strs) / sizeof(mpd_cmd_strs[0]); i++)
+        if (!strncmp(cmd, mpd_cmd_strs[i], strlen(mpd_cmd_strs[i])))
             return i;
 
     return -1;
 }
 
-int callback_mpd(struct mg_connection *c)
-{
+int callback_mpd(struct mg_connection *c) {
     enum mpd_cmd_ids cmd_id = get_cmd_id(c->content);
     size_t n = 0;
     unsigned int uint_buf, uint_buf_2;
     int int_buf;
     char *p_charbuf = NULL, *token;
 
-    if(cmd_id == -1)
+    if (cmd_id == -1)
         return MG_TRUE;
 
-    if(mpd.conn_state != MPD_CONNECTED && cmd_id != MPD_API_SET_MPDHOST &&
+    if (mpd.conn_state != MPD_CONNECTED && cmd_id != MPD_API_SET_MPDHOST &&
         cmd_id != MPD_API_GET_MPDHOST && cmd_id != MPD_API_SET_MPDPASS)
         return MG_TRUE;
 
-    switch(cmd_id)
-    {
+    switch (cmd_id) {
         case MPD_API_UPDATE_DB:
             mpd_run_update(mpd.conn, NULL);
             break;
@@ -92,43 +88,42 @@ int callback_mpd(struct mg_connection *c)
             mpd_run_clear(mpd.conn);
             break;
         case MPD_API_RM_TRACK:
-            if(sscanf(c->content, "MPD_API_RM_TRACK,%u", &uint_buf))
+            if (sscanf(c->content, "MPD_API_RM_TRACK,%u", &uint_buf))
                 mpd_run_delete_id(mpd.conn, uint_buf);
             break;
         case MPD_API_RM_RANGE:
-            if(sscanf(c->content, "MPD_API_RM_RANGE,%u,%u", &uint_buf, &uint_buf_2))
+            if (sscanf(c->content, "MPD_API_RM_RANGE,%u,%u", &uint_buf, &uint_buf_2))
                 mpd_run_delete_range(mpd.conn, uint_buf, uint_buf_2);
             break;
         case MPD_API_MOVE_TRACK:
-            if (sscanf(c->content, "MPD_API_MOVE_TRACK,%u,%u", &uint_buf, &uint_buf_2) == 2)
-            {
+            if (sscanf(c->content, "MPD_API_MOVE_TRACK,%u,%u", &uint_buf, &uint_buf_2) == 2) {
                 uint_buf -= 1;
                 uint_buf_2 -= 1;
                 mpd_run_move(mpd.conn, uint_buf, uint_buf_2);
             }
             break;
         case MPD_API_PLAY_TRACK:
-            if(sscanf(c->content, "MPD_API_PLAY_TRACK,%u", &uint_buf))
+            if (sscanf(c->content, "MPD_API_PLAY_TRACK,%u", &uint_buf))
                 mpd_run_play_id(mpd.conn, uint_buf);
             break;
         case MPD_API_TOGGLE_RANDOM:
-            if(sscanf(c->content, "MPD_API_TOGGLE_RANDOM,%u", &uint_buf))
+            if (sscanf(c->content, "MPD_API_TOGGLE_RANDOM,%u", &uint_buf))
                 mpd_run_random(mpd.conn, uint_buf);
             break;
         case MPD_API_TOGGLE_REPEAT:
-            if(sscanf(c->content, "MPD_API_TOGGLE_REPEAT,%u", &uint_buf))
+            if (sscanf(c->content, "MPD_API_TOGGLE_REPEAT,%u", &uint_buf))
                 mpd_run_repeat(mpd.conn, uint_buf);
             break;
         case MPD_API_TOGGLE_CONSUME:
-            if(sscanf(c->content, "MPD_API_TOGGLE_CONSUME,%u", &uint_buf))
+            if (sscanf(c->content, "MPD_API_TOGGLE_CONSUME,%u", &uint_buf))
                 mpd_run_consume(mpd.conn, uint_buf);
             break;
         case MPD_API_TOGGLE_SINGLE:
-            if(sscanf(c->content, "MPD_API_TOGGLE_SINGLE,%u", &uint_buf))
+            if (sscanf(c->content, "MPD_API_TOGGLE_SINGLE,%u", &uint_buf))
                 mpd_run_single(mpd.conn, uint_buf);
             break;
         case MPD_API_TOGGLE_CROSSFADE:
-            if(sscanf(c->content, "MPD_API_TOGGLE_CROSSFADE,%u", &uint_buf))
+            if (sscanf(c->content, "MPD_API_TOGGLE_CROSSFADE,%u", &uint_buf))
                 mpd_run_crossfade(mpd.conn, uint_buf);
             break;
         case MPD_API_GET_OUTPUTS:
@@ -145,123 +140,123 @@ int callback_mpd(struct mg_connection *c)
             }
             break;
         case MPD_API_SET_VOLUME:
-            if(sscanf(c->content, "MPD_API_SET_VOLUME,%ud", &uint_buf) && uint_buf <= 100)
+            if (sscanf(c->content, "MPD_API_SET_VOLUME,%ud", &uint_buf) && uint_buf <= 100)
                 mpd_run_set_volume(mpd.conn, uint_buf);
             break;
         case MPD_API_SET_SEEK:
-            if(sscanf(c->content, "MPD_API_SET_SEEK,%u,%u", &uint_buf, &uint_buf_2))
+            if (sscanf(c->content, "MPD_API_SET_SEEK,%u,%u", &uint_buf, &uint_buf_2))
                 mpd_run_seek_id(mpd.conn, uint_buf, uint_buf_2);
             break;
         case MPD_API_GET_QUEUE:
-            if(sscanf(c->content, "MPD_API_GET_QUEUE,%u", &uint_buf))
+            if (sscanf(c->content, "MPD_API_GET_QUEUE,%u", &uint_buf))
                 n = mpd_put_queue(mpd.buf, uint_buf);
             break;
         case MPD_API_GET_BROWSE:
             p_charbuf = strdup(c->content);
-            if(strcmp(strtok(p_charbuf, ","), "MPD_API_GET_BROWSE"))
+            if (strcmp(strtok(p_charbuf, ","), "MPD_API_GET_BROWSE"))
                 goto out_browse;
 
             uint_buf = strtoul(strtok(NULL, ","), NULL, 10);
-            if((token = strtok(NULL, ",")) == NULL)
+            if ((token = strtok(NULL, ",")) == NULL)
                 goto out_browse;
 
-			free(p_charbuf);
+            free(p_charbuf);
             p_charbuf = strdup(c->content);
             n = mpd_put_browse(mpd.buf, get_arg2(p_charbuf), uint_buf);
-out_browse:
-			free(p_charbuf);
+        out_browse:
+            free(p_charbuf);
             break;
         case MPD_API_ADD_TRACK:
             p_charbuf = strdup(c->content);
-            if(strcmp(strtok(p_charbuf, ","), "MPD_API_ADD_TRACK"))
+            if (strcmp(strtok(p_charbuf, ","), "MPD_API_ADD_TRACK"))
                 goto out_add_track;
 
-            if((token = strtok(NULL, ",")) == NULL)
+            if ((token = strtok(NULL, ",")) == NULL)
                 goto out_add_track;
 
-			free(p_charbuf);
+            free(p_charbuf);
             p_charbuf = strdup(c->content);
             mpd_run_add(mpd.conn, get_arg1(p_charbuf));
-out_add_track:
+        out_add_track:
             free(p_charbuf);
             break;
         case MPD_API_ADD_PLAY_TRACK:
             p_charbuf = strdup(c->content);
-            if(strcmp(strtok(p_charbuf, ","), "MPD_API_ADD_PLAY_TRACK"))
+            if (strcmp(strtok(p_charbuf, ","), "MPD_API_ADD_PLAY_TRACK"))
                 goto out_play_track;
 
-            if((token = strtok(NULL, ",")) == NULL)
+            if ((token = strtok(NULL, ",")) == NULL)
                 goto out_play_track;
 
-			free(p_charbuf);
+            free(p_charbuf);
             p_charbuf = strdup(c->content);
             int_buf = mpd_run_add_id(mpd.conn, get_arg1(p_charbuf));
-            if(int_buf != -1)
+            if (int_buf != -1)
                 mpd_run_play_id(mpd.conn, int_buf);
-out_play_track:
+        out_play_track:
             free(p_charbuf);
             break;
         case MPD_API_ADD_PLAYLIST:
             p_charbuf = strdup(c->content);
-            if(strcmp(strtok(p_charbuf, ","), "MPD_API_ADD_PLAYLIST"))
+            if (strcmp(strtok(p_charbuf, ","), "MPD_API_ADD_PLAYLIST"))
                 goto out_playlist;
 
-            if((token = strtok(NULL, ",")) == NULL)
+            if ((token = strtok(NULL, ",")) == NULL)
                 goto out_playlist;
 
-			free(p_charbuf);
+            free(p_charbuf);
             p_charbuf = strdup(c->content);
             mpd_run_load(mpd.conn, get_arg1(p_charbuf));
-out_playlist:
+        out_playlist:
             free(p_charbuf);
             break;
         case MPD_API_SAVE_QUEUE:
             p_charbuf = strdup(c->content);
-            if(strcmp(strtok(p_charbuf, ","), "MPD_API_SAVE_QUEUE"))
+            if (strcmp(strtok(p_charbuf, ","), "MPD_API_SAVE_QUEUE"))
                 goto out_save_queue;
 
-            if((token = strtok(NULL, ",")) == NULL)
+            if ((token = strtok(NULL, ",")) == NULL)
                 goto out_save_queue;
 
-			free(p_charbuf);
+            free(p_charbuf);
             p_charbuf = strdup(c->content);
             mpd_run_save(mpd.conn, get_arg1(p_charbuf));
-out_save_queue:
+        out_save_queue:
             free(p_charbuf);
             break;
         case MPD_API_SEARCH:
             p_charbuf = strdup(c->content);
-            if(strcmp(strtok(p_charbuf, ","), "MPD_API_SEARCH"))
-				goto out_search;
-
-            if((token = strtok(NULL, ",")) == NULL)
+            if (strcmp(strtok(p_charbuf, ","), "MPD_API_SEARCH"))
                 goto out_search;
 
-			free(p_charbuf);
+            if ((token = strtok(NULL, ",")) == NULL)
+                goto out_search;
+
+            free(p_charbuf);
             p_charbuf = strdup(c->content);
             n = mpd_search(mpd.buf, get_arg1(p_charbuf));
-out_search:
+        out_search:
             free(p_charbuf);
             break;
         case MPD_API_SEND_MESSAGE:
             p_charbuf = strdup(c->content);
-            if(strcmp(strtok(p_charbuf, ","), "MPD_API_SEND_MESSAGE"))
-				goto out_send_message;
-
-            if((token = strtok(NULL, ",")) == NULL)
+            if (strcmp(strtok(p_charbuf, ","), "MPD_API_SEND_MESSAGE"))
                 goto out_send_message;
 
-			free(p_charbuf);
+            if ((token = strtok(NULL, ",")) == NULL)
+                goto out_send_message;
+
+            free(p_charbuf);
             p_charbuf = strdup(get_arg1(c->content));
 
-            if ( strtok(p_charbuf, ",") == NULL )
+            if (strtok(p_charbuf, ",") == NULL)
                 goto out_send_message;
 
-            if ( (token = strtok(NULL, ",")) == NULL )
+            if ((token = strtok(NULL, ",")) == NULL)
                 goto out_send_message;
 
-			mpd_run_send_message(mpd.conn, p_charbuf, token);
-out_send_message:
+            mpd_run_send_message(mpd.conn, p_charbuf, token);
+        out_send_message:
             free(p_charbuf);
             break;
 #ifdef WITH_MPD_HOST_CHANGE
@@ -269,13 +264,13 @@ out_send_message:
         case MPD_API_SET_MPDHOST:
             int_buf = 0;
             p_charbuf = strdup(c->content);
-            if(strcmp(strtok(p_charbuf, ","), "MPD_API_SET_MPDHOST"))
+            if (strcmp(strtok(p_charbuf, ","), "MPD_API_SET_MPDHOST"))
                 goto out_host_change;
 
-            if((int_buf = strtol(strtok(NULL, ","), NULL, 10)) <= 0)
+            if ((int_buf = strtol(strtok(NULL, ","), NULL, 10)) <= 0)
                 goto out_host_change;
 
-            if((token = strtok(NULL, ",")) == NULL)
+            if ((token = strtok(NULL, ",")) == NULL)
                 goto out_host_change;
 
             strncpy(mpd.host, token, sizeof(mpd.host));
@@ -283,55 +278,56 @@ out_send_message:
             mpd.conn_state = MPD_RECONNECT;
             free(p_charbuf);
             return MG_TRUE;
-out_host_change:
+        out_host_change:
             free(p_charbuf);
             break;
         case MPD_API_GET_MPDHOST:
-            n = snprintf(mpd.buf, MAX_SIZE, "{\"type\":\"mpdhost\", \"data\": "
-                "{\"host\" : \"%s\", \"port\": \"%d\", \"passwort_set\": %s}"
-                "}", mpd.host, mpd.port, mpd.password ? "true" : "false");
+            n = snprintf(mpd.buf, MAX_SIZE,
+                         "{\"type\":\"mpdhost\", \"data\": "
+                         "{\"host\" : \"%s\", \"port\": \"%d\", \"passwort_set\": %s}"
+                         "}",
+                         mpd.host, mpd.port, mpd.password ? "true" : "false");
             break;
         case MPD_API_SET_MPDPASS:
             p_charbuf = strdup(c->content);
-            if(strcmp(strtok(p_charbuf, ","), "MPD_API_SET_MPDPASS"))
+            if (strcmp(strtok(p_charbuf, ","), "MPD_API_SET_MPDPASS"))
                 goto out_set_pass;
 
-            if((token = strtok(NULL, ",")) == NULL)
+            if ((token = strtok(NULL, ",")) == NULL)
                 goto out_set_pass;
 
-            if(mpd.password)
+            if (mpd.password)
                 free(mpd.password);
 
             mpd.password = strdup(token);
             mpd.conn_state = MPD_RECONNECT;
             free(p_charbuf);
             return MG_TRUE;
-out_set_pass:
+        out_set_pass:
             free(p_charbuf);
             break;
 #endif
     }
 
-    if(mpd.conn_state == MPD_CONNECTED && mpd_connection_get_error(mpd.conn) != MPD_ERROR_SUCCESS)
-    {
-        n = snprintf(mpd.buf, MAX_SIZE, "{\"type\":\"error\", \"data\": \"%s\"}", 
-            mpd_connection_get_error_message(mpd.conn));
+    if (mpd.conn_state == MPD_CONNECTED &&
+        mpd_connection_get_error(mpd.conn) != MPD_ERROR_SUCCESS) {
+        n = snprintf(mpd.buf, MAX_SIZE, "{\"type\":\"error\", \"data\": \"%s\"}",
+                     mpd_connection_get_error_message(mpd.conn));
 
         /* Try to recover error */
         if (!mpd_connection_clear_error(mpd.conn))
             mpd.conn_state = MPD_FAILURE;
     }
 
-    if(n > 0)
+    if (n > 0)
         mg_websocket_write(c, 1, mpd.buf, n);
 
     return MG_TRUE;
 }
 
-int mpd_close_handler(struct mg_connection *c)
-{
+int mpd_close_handler(struct mg_connection *c) {
     /* Cleanup session data */
-    if(c->connection_param)
+    if (c->connection_param)
         free(c->connection_param);
     return 0;
 }
@@ -339,41 +335,36 @@ int mpd_close_handler(struct mg_connection *c)
 static int mpd_notify_callback(struct mg_connection *c, enum mg_event ev) {
     size_t n;
 
-    if(!c->is_websocket)
+    if (!c->is_websocket)
         return MG_TRUE;
 
-    if(c->callback_param)
-    {
+    if (c->callback_param) {
         /* error message? */
-        n = snprintf(mpd.buf, MAX_SIZE, "{\"type\":\"error\",\"data\":\"%s\"}", 
-            (const char *)c->callback_param);
+        n = snprintf(mpd.buf, MAX_SIZE, "{\"type\":\"error\",\"data\":\"%s\"}",
+                     (const char *)c->callback_param);
 
         mg_websocket_write(c, 1, mpd.buf, n);
         return MG_TRUE;
     }
 
-    if(!c->connection_param)
+    if (!c->connection_param)
         c->connection_param = calloc(1, sizeof(struct t_mpd_client_session));
 
     struct t_mpd_client_session *s = (struct t_mpd_client_session *)c->connection_param;
 
-    if(mpd.conn_state != MPD_CONNECTED) {
+    if (mpd.conn_state != MPD_CONNECTED) {
         n = snprintf(mpd.buf, MAX_SIZE, "{\"type\":\"disconnected\"}");
         mg_websocket_write(c, 1, mpd.buf, n);
-    }
-    else
-    {
+    } else {
         mg_websocket_write(c, 1, mpd.buf, mpd.buf_size);
 
-        if(s->song_id != mpd.song_id)
-        {
+        if (s->song_id != mpd.song_id) {
             n = mpd_put_current_song(mpd.buf);
             mg_websocket_write(c, 1, mpd.buf, n);
             s->song_id = mpd.song_id;
         }
 
-        if(s->queue_version != mpd.queue_version)
-        {
+        if (s->queue_version != mpd.queue_version) {
             n = snprintf(mpd.buf, MAX_SIZE, "{\"type\":\"update_queue\"}");
             mg_websocket_write(c, 1, mpd.buf, n);
             s->queue_version = mpd.queue_version;
@@ -383,8 +374,7 @@ static int mpd_notify_callback(struct mg_connection *c, enum mg_event ev) {
     return MG_TRUE;
 }
 
-void mpd_poll(struct mg_server *s)
-{
+void mpd_poll(struct mg_server *s) {
     switch (mpd.conn_state) {
         case MPD_DISCONNECTED:
             /* Try to connect */
@@ -398,8 +388,7 @@ void mpd_poll(struct mg_server *s)
 
             if (mpd_connection_get_error(mpd.conn) != MPD_ERROR_SUCCESS) {
                 fprintf(stderr, "MPD connection: %s\n", mpd_connection_get_error_message(mpd.conn));
-                for (struct mg_connection *c = mg_next(s, NULL); c != NULL; c = mg_next(s, c))
-                {
+                for (struct mg_connection *c = mg_next(s, NULL); c != NULL; c = mg_next(s, c)) {
                     c->callback_param = (void *)mpd_connection_get_error_message(mpd.conn);
                     mpd_notify_callback(c, MG_POLL);
                 }
@@ -407,11 +396,9 @@ void mpd_poll(struct mg_server *s)
                 return;
             }
 
-            if(mpd.password && !mpd_run_password(mpd.conn, mpd.password))
-            {
+            if (mpd.password && !mpd_run_password(mpd.conn, mpd.password)) {
                 fprintf(stderr, "MPD connection: %s\n", mpd_connection_get_error_message(mpd.conn));
-                for (struct mg_connection *c = mg_next(s, NULL); c != NULL; c = mg_next(s, c))
-                {
+                for (struct mg_connection *c = mg_next(s, NULL); c != NULL; c = mg_next(s, c)) {
                     c->callback_param = (void *)mpd_connection_get_error_message(mpd.conn);
                     mpd_notify_callback(c, MG_POLL);
                 }
@@ -424,8 +411,7 @@ void mpd_poll(struct mg_server *s)
             mpd.conn_state = MPD_CONNECTED;
             /* write outputs */
             mpd.buf_size = mpd_put_outputs(mpd.buf, 1);
-            for (struct mg_connection *c = mg_next(s, NULL); c != NULL; c = mg_next(s, c))
-            {
+            for (struct mg_connection *c = mg_next(s, NULL); c != NULL; c = mg_next(s, c)) {
                 c->callback_param = NULL;
                 mpd_notify_callback(c, MG_POLL);
             }
@@ -436,7 +422,7 @@ void mpd_poll(struct mg_server *s)
 
         case MPD_DISCONNECT:
         case MPD_RECONNECT:
-            if(mpd.conn != NULL)
+            if (mpd.conn != NULL)
                 mpd_connection_free(mpd.conn);
             mpd.conn = NULL;
             mpd.conn_state = MPD_DISCONNECTED;
@@ -444,14 +430,12 @@ void mpd_poll(struct mg_server *s)
 
         case MPD_CONNECTED:
             mpd.buf_size = mpd_put_state(mpd.buf, &mpd.song_id, &mpd.queue_version);
-            for (struct mg_connection *c = mg_next(s, NULL); c != NULL; c = mg_next(s, c))
-            {
+            for (struct mg_connection *c = mg_next(s, NULL); c != NULL; c = mg_next(s, c)) {
                 c->callback_param = NULL;
                 mpd_notify_callback(c, MG_POLL);
             }
             mpd.buf_size = mpd_put_outputs(mpd.buf, 0);
-            for (struct mg_connection *c = mg_next(s, NULL); c != NULL; c = mg_next(s, c))
-            {
+            for (struct mg_connection *c = mg_next(s, NULL); c != NULL; c = mg_next(s, c)) {
                 c->callback_param = NULL;
                 mpd_notify_callback(c, MG_POLL);
             }
@@ -459,56 +443,51 @@ void mpd_poll(struct mg_server *s)
     }
 }
 
-char* mpd_get_title(struct mpd_song const *song)
-{
+char *mpd_get_title(struct mpd_song const *song) {
     char *str;
 
     str = (char *)mpd_song_get_tag(song, MPD_TAG_TITLE, 0);
-    if(str == NULL){
+    if (str == NULL) {
         str = basename((char *)mpd_song_get_uri(song));
     }
 
     return str;
 }
 
-char* mpd_get_album(struct mpd_song const *song)
-{
+char *mpd_get_album(struct mpd_song const *song) {
     char *str;
 
     str = (char *)mpd_song_get_tag(song, MPD_TAG_ALBUM, 0);
-    if(str == NULL){
+    if (str == NULL) {
         str = "-";
     }
 
     return str;
 }
 
-char* mpd_get_artist(struct mpd_song const *song)
-{
+char *mpd_get_artist(struct mpd_song const *song) {
     char *str;
 
     str = (char *)mpd_song_get_tag(song, MPD_TAG_ARTIST, 0);
-    if(str == NULL){
+    if (str == NULL) {
         str = "-";
     }
 
     return str;
 }
 
-char* mpd_get_year(struct mpd_song const *song)
-{
+char *mpd_get_year(struct mpd_song const *song) {
     char *str;
 
     str = (char *)mpd_song_get_tag(song, MPD_TAG_DATE, 0);
-    if(str == NULL){
+    if (str == NULL) {
         str = "-";
     }
 
     return str;
 }
 
-int mpd_put_state(char *buffer, int *current_song_id, unsigned *queue_version)
-{
+int mpd_put_state(char *buffer, int *current_song_id, unsigned *queue_version) {
     struct mpd_status *status;
     int len;
 
@@ -520,23 +499,18 @@ int mpd_put_state(char *buffer, int *current_song_id, unsigned *queue_version)
     }
 
     len = snprintf(buffer, MAX_SIZE,
-        "{\"type\":\"state\", \"data\":{"
-        " \"state\":%d, \"volume\":%d, \"repeat\":%d,"
-        " \"single\":%d, \"crossfade\":%d, \"consume\":%d, \"random\":%d, "
-        " \"songpos\": %d, \"elapsedTime\": %d, \"totalTime\":%d, "
-        " \"currentsongid\": %d"
-        "}}", 
-        mpd_status_get_state(status),
-        mpd_status_get_volume(status), 
-        mpd_status_get_repeat(status),
-        mpd_status_get_single(status),
-        mpd_status_get_crossfade(status),
-        mpd_status_get_consume(status),
-        mpd_status_get_random(status),
-        mpd_status_get_song_pos(status),
-        mpd_status_get_elapsed_time(status),
-        mpd_status_get_total_time(status),
-        mpd_status_get_song_id(status));
+                   "{\"type\":\"state\", \"data\":{"
+                   " \"state\":%d, \"volume\":%d, \"repeat\":%d,"
+                   " \"single\":%d, \"crossfade\":%d, \"consume\":%d, \"random\":%d, "
+                   " \"songpos\": %d, \"elapsedTime\": %d, \"totalTime\":%d, "
+                   " \"currentsongid\": %d"
+                   "}}",
+                   mpd_status_get_state(status), mpd_status_get_volume(status),
+                   mpd_status_get_repeat(status), mpd_status_get_single(status),
+                   mpd_status_get_crossfade(status), mpd_status_get_consume(status),
+                   mpd_status_get_random(status), mpd_status_get_song_pos(status),
+                   mpd_status_get_elapsed_time(status), mpd_status_get_total_time(status),
+                   mpd_status_get_song_id(status));
 
     *current_song_id = mpd_status_get_song_id(status);
     *queue_version = mpd_status_get_queue_version(status);
@@ -544,16 +518,15 @@ int mpd_put_state(char *buffer, int *current_song_id, unsigned *queue_version)
     return len;
 }
 
-int mpd_put_outputs(char *buffer, int names)
-{
+int mpd_put_outputs(char *buffer, int names) {
     struct mpd_output *out;
     int nout;
     char *str, *strend;
 
     str = buffer;
-    strend = buffer+MAX_SIZE;
-    str += snprintf(str, strend-str, "{\"type\":\"%s\", \"data\":{",
-            names ? "outputnames" : "outputs");
+    strend = buffer + MAX_SIZE;
+    str += snprintf(str, strend - str, "{\"type\":\"%s\", \"data\":{",
+                    names ? "outputnames" : "outputs");
 
     mpd_send_outputs(mpd.conn);
     nout = 0;
@@ -561,11 +534,11 @@ int mpd_put_outputs(char *buffer, int names)
         if (nout++)
             *str++ = ',';
         if (names)
-            str += snprintf(str, strend - str, " \"%d\":\"%s\"",
-                    mpd_output_get_id(out), mpd_output_get_name(out));
+            str += snprintf(str, strend - str, " \"%d\":\"%s\"", mpd_output_get_id(out),
+                            mpd_output_get_name(out));
         else
-            str += snprintf(str, strend-str, " \"%d\":%d",
-                    mpd_output_get_id(out), mpd_output_get_enabled(out));
+            str += snprintf(str, strend - str, " \"%d\":%d", mpd_output_get_id(out),
+                            mpd_output_get_enabled(out));
         mpd_output_free(out);
     }
     if (!mpd_response_finish(mpd.conn)) {
@@ -573,18 +546,17 @@ int mpd_put_outputs(char *buffer, int names)
         mpd_connection_clear_error(mpd.conn);
         return 0;
     }
-    str += snprintf(str, strend-str, " }}");
-    return str-buffer;
+    str += snprintf(str, strend - str, " }}");
+    return str - buffer;
 }
 
-int mpd_put_current_song(char *buffer)
-{
+int mpd_put_current_song(char *buffer) {
     char *cur = buffer;
     const char *end = buffer + MAX_SIZE;
     struct mpd_song *song;
 
     song = mpd_run_current_song(mpd.conn);
-    if(song == NULL)
+    if (song == NULL)
         return 0;
 
     cur += json_emit_raw_str(cur, end - cur, "{\"type\": \"song_change\", \"data\":{\"pos\":");
@@ -603,23 +575,22 @@ int mpd_put_current_song(char *buffer)
     return cur - buffer;
 }
 
-int mpd_put_queue(char *buffer, unsigned int offset)
-{
+int mpd_put_queue(char *buffer, unsigned int offset) {
     char *cur = buffer;
     const char *end = buffer + MAX_SIZE;
     struct mpd_entity *entity;
     unsigned long totalTime = 0;
 
-    if (!mpd_send_list_queue_range_meta(mpd.conn, offset, offset+MAX_ELEMENTS_PER_PAGE))
+    if (!mpd_send_list_queue_range_meta(mpd.conn, offset, offset + MAX_ELEMENTS_PER_PAGE))
         RETURN_ERROR_AND_RECOVER("mpd_send_list_queue_meta");
 
-    cur += json_emit_raw_str(cur, end  - cur, "{\"type\":\"queue\",\"data\":[ ");
+    cur += json_emit_raw_str(cur, end - cur, "{\"type\":\"queue\",\"data\":[ ");
 
-    while((entity = mpd_recv_entity(mpd.conn)) != NULL) {
+    while ((entity = mpd_recv_entity(mpd.conn)) != NULL) {
         const struct mpd_song *song;
         unsigned int drtn;
 
-        if(mpd_entity_get_type(entity) == MPD_ENTITY_TYPE_SONG) {
+        if (mpd_entity_get_type(entity) == MPD_ENTITY_TYPE_SONG) {
             song = mpd_entity_get_song(entity);
             drtn = mpd_song_get_duration(song);
 
@@ -655,8 +626,7 @@ int mpd_put_queue(char *buffer, unsigned int offset)
     return cur - buffer;
 }
 
-int mpd_put_browse(char *buffer, char *path, unsigned int offset)
-{
+int mpd_put_browse(char *buffer, char *path, unsigned int offset) {
     char *cur = buffer;
     const char *end = buffer + MAX_SIZE;
     struct mpd_entity *entity;
@@ -665,25 +635,22 @@ int mpd_put_browse(char *buffer, char *path, unsigned int offset)
     if (!mpd_send_list_meta(mpd.conn, path))
         RETURN_ERROR_AND_RECOVER("mpd_send_list_meta");
 
-    cur += json_emit_raw_str(cur, end  - cur, "{\"type\":\"browse\",\"data\":[ ");
+    cur += json_emit_raw_str(cur, end - cur, "{\"type\":\"browse\",\"data\":[ ");
 
-    while((entity = mpd_recv_entity(mpd.conn)) != NULL) {
+    while ((entity = mpd_recv_entity(mpd.conn)) != NULL) {
         const struct mpd_song *song;
         const struct mpd_directory *dir;
         const struct mpd_playlist *pl;
 
-        if(offset > entity_count)
-        {
+        if (offset > entity_count) {
             mpd_entity_free(entity);
             entity_count++;
             continue;
-        }
-        else if(offset + MAX_ELEMENTS_PER_PAGE - 1 < entity_count)
-        {
+        } else if (offset + MAX_ELEMENTS_PER_PAGE - 1 < entity_count) {
             mpd_entity_free(entity);
-            cur += json_emit_raw_str(cur, end  - cur, "{\"type\":\"wrap\",\"count\":");
+            cur += json_emit_raw_str(cur, end - cur, "{\"type\":\"wrap\",\"count\":");
             cur += json_emit_int(cur, end - cur, entity_count);
-            cur += json_emit_raw_str(cur, end  - cur, "} ");
+            cur += json_emit_raw_str(cur, end - cur, "} ");
             break;
         }
 
@@ -738,23 +705,22 @@ int mpd_put_browse(char *buffer, char *path, unsigned int offset)
     return cur - buffer;
 }
 
-int mpd_search(char *buffer, char *searchstr)
-{
+int mpd_search(char *buffer, char *searchstr) {
     int i = 0;
     char *cur = buffer;
     const char *end = buffer + MAX_SIZE;
     struct mpd_song *song;
 
-    if(mpd_search_db_songs(mpd.conn, false) == false)
+    if (mpd_search_db_songs(mpd.conn, false) == false)
         RETURN_ERROR_AND_RECOVER("mpd_search_db_songs");
-    else if(mpd_search_add_any_tag_constraint(mpd.conn, MPD_OPERATOR_DEFAULT, searchstr) == false)
+    else if (mpd_search_add_any_tag_constraint(mpd.conn, MPD_OPERATOR_DEFAULT, searchstr) == false)
         RETURN_ERROR_AND_RECOVER("mpd_search_add_any_tag_constraint");
-    else if(mpd_search_commit(mpd.conn) == false)
+    else if (mpd_search_commit(mpd.conn) == false)
         RETURN_ERROR_AND_RECOVER("mpd_search_commit");
     else {
         cur += json_emit_raw_str(cur, end - cur, "{\"type\":\"search\",\"data\":[ ");
 
-        while((song = mpd_recv_song(mpd.conn)) != NULL) {
+        while ((song = mpd_recv_song(mpd.conn)) != NULL) {
             cur += json_emit_raw_str(cur, end - cur, "{\"type\":\"song\",\"uri\":");
             cur += json_emit_quoted_str(cur, end - cur, mpd_song_get_uri(song));
             cur += json_emit_raw_str(cur, end - cur, ",\"album\":");
@@ -773,8 +739,7 @@ int mpd_search(char *buffer, char *searchstr)
             mpd_song_free(song);
 
             /* Maximum results */
-            if(i++ >= 300)
-            {
+            if (i++ >= 300) {
                 cur += json_emit_raw_str(cur, end - cur, "{\"type\":\"wrap\"},");
                 break;
             }
@@ -788,9 +753,7 @@ int mpd_search(char *buffer, char *searchstr)
     return cur - buffer;
 }
 
-
-void mpd_disconnect()
-{
+void mpd_disconnect() {
     mpd.conn_state = MPD_DISCONNECT;
     mpd_poll(NULL);
 }

--- a/src/mpd_client.h
+++ b/src/mpd_client.h
@@ -1,7 +1,7 @@
 /* ympd
    (c) 2013-2014 Andrew Karpow <andy@ndyk.de>
    This project's homepage is: http://www.ympd.org
-   
+
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
    the Free Software Foundation; version 2 of the License.
@@ -15,63 +15,61 @@
    with this program; if not, write to the Free Software Foundation, Inc.,
    Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
-   
+
 #ifndef __MPD_CLIENT_H__
 #define __MPD_CLIENT_H__
 
 #include "mongoose.h"
 
-#define RETURN_ERROR_AND_RECOVER(X) do { \
-    fprintf(stderr, "MPD X: %s\n", mpd_connection_get_error_message(mpd.conn)); \
-    cur += snprintf(cur, end  - cur, "{\"type\":\"error\",\"data\":\"%s\"}", \
-    mpd_connection_get_error_message(mpd.conn)); \
-    if (!mpd_connection_clear_error(mpd.conn)) \
-        mpd.conn_state = MPD_FAILURE; \
-    return cur - buffer; \
-} while(0)
-
+#define RETURN_ERROR_AND_RECOVER(X)                                                 \
+    do {                                                                            \
+        fprintf(stderr, "MPD X: %s\n", mpd_connection_get_error_message(mpd.conn)); \
+        cur += snprintf(cur, end - cur, "{\"type\":\"error\",\"data\":\"%s\"}",     \
+                        mpd_connection_get_error_message(mpd.conn));                \
+        if (!mpd_connection_clear_error(mpd.conn))                                  \
+            mpd.conn_state = MPD_FAILURE;                                           \
+        return cur - buffer;                                                        \
+    } while (0)
 
 #define MAX_SIZE 1024 * 100
 #define MAX_ELEMENTS_PER_PAGE 512
 
 #define GEN_ENUM(X) X,
 #define GEN_STR(X) #X,
-#define MPD_CMDS(X) \
-    X(MPD_API_GET_QUEUE) \
-    X(MPD_API_GET_BROWSE) \
-    X(MPD_API_GET_MPDHOST) \
-    X(MPD_API_ADD_TRACK) \
-    X(MPD_API_ADD_PLAY_TRACK) \
-    X(MPD_API_ADD_PLAYLIST) \
-    X(MPD_API_PLAY_TRACK) \
-    X(MPD_API_SAVE_QUEUE) \
-    X(MPD_API_RM_TRACK) \
-    X(MPD_API_RM_RANGE) \
-    X(MPD_API_RM_ALL) \
-    X(MPD_API_MOVE_TRACK) \
-    X(MPD_API_SEARCH) \
-    X(MPD_API_SEND_MESSAGE) \
-    X(MPD_API_SET_VOLUME) \
-    X(MPD_API_SET_PAUSE) \
-    X(MPD_API_SET_PLAY) \
-    X(MPD_API_SET_STOP) \
-    X(MPD_API_SET_SEEK) \
-    X(MPD_API_SET_NEXT) \
-    X(MPD_API_SET_PREV) \
-    X(MPD_API_SET_MPDHOST) \
-    X(MPD_API_SET_MPDPASS) \
-    X(MPD_API_UPDATE_DB) \
-    X(MPD_API_GET_OUTPUTS) \
-    X(MPD_API_TOGGLE_OUTPUT) \
-    X(MPD_API_TOGGLE_RANDOM) \
-    X(MPD_API_TOGGLE_CONSUME) \
-    X(MPD_API_TOGGLE_SINGLE) \
+#define MPD_CMDS(X)             \
+    X(MPD_API_GET_QUEUE)        \
+    X(MPD_API_GET_BROWSE)       \
+    X(MPD_API_GET_MPDHOST)      \
+    X(MPD_API_ADD_TRACK)        \
+    X(MPD_API_ADD_PLAY_TRACK)   \
+    X(MPD_API_ADD_PLAYLIST)     \
+    X(MPD_API_PLAY_TRACK)       \
+    X(MPD_API_SAVE_QUEUE)       \
+    X(MPD_API_RM_TRACK)         \
+    X(MPD_API_RM_RANGE)         \
+    X(MPD_API_RM_ALL)           \
+    X(MPD_API_MOVE_TRACK)       \
+    X(MPD_API_SEARCH)           \
+    X(MPD_API_SEND_MESSAGE)     \
+    X(MPD_API_SET_VOLUME)       \
+    X(MPD_API_SET_PAUSE)        \
+    X(MPD_API_SET_PLAY)         \
+    X(MPD_API_SET_STOP)         \
+    X(MPD_API_SET_SEEK)         \
+    X(MPD_API_SET_NEXT)         \
+    X(MPD_API_SET_PREV)         \
+    X(MPD_API_SET_MPDHOST)      \
+    X(MPD_API_SET_MPDPASS)      \
+    X(MPD_API_UPDATE_DB)        \
+    X(MPD_API_GET_OUTPUTS)      \
+    X(MPD_API_TOGGLE_OUTPUT)    \
+    X(MPD_API_TOGGLE_RANDOM)    \
+    X(MPD_API_TOGGLE_CONSUME)   \
+    X(MPD_API_TOGGLE_SINGLE)    \
     X(MPD_API_TOGGLE_CROSSFADE) \
     X(MPD_API_TOGGLE_REPEAT)
 
-enum mpd_cmd_ids {
-    MPD_CMDS(GEN_ENUM)
-};
+enum mpd_cmd_ids { MPD_CMDS(GEN_ENUM) };
 
 enum mpd_conn_states {
     MPD_DISCONNECTED,
@@ -83,10 +81,10 @@ enum mpd_conn_states {
 
 struct t_mpd {
     int port;
-	int local_port;
+    int local_port;
     char host[128];
     char *password;
-	char *gpass;
+    char *gpass;
 
     struct mpd_connection *conn;
     enum mpd_conn_states conn_state;
@@ -117,4 +115,3 @@ int mpd_put_browse(char *buffer, char *path, unsigned int offset);
 int mpd_search(char *buffer, char *searchstr);
 void mpd_disconnect();
 #endif
-


### PR DESCRIPTION
Changes:

- added the configuration files for prettier and clang-format
- added a gitignore file
- added a DEVELOPMENT.md file with information about how to run the linters.

Ran the linters on the ympd specific sources.  I tried to keep the format as close as possible but it still ended up with some massive changes (mainly due to spacing, etc) The only source file change, other than the lint runs, was to add a comment to disable/enable the linter in ympd.c. I'll tag the location in a comment. 

Please extract the configuration files and run the linters yourself against the master branch. The resulting changes should match the files in the PR. 

I compiled and it ran without issue.

I probably have one more maintenance task on the plate before I look towards figuring out some new features. Namely, upgrading the libraries to something a bit more recent. Because while I'm running this rather isolated doesn't mean someone isn't running this exposed to the internet...