### PR TITLE
Move the panel header to the list panel

### DIFF
--- a/htdocs/index.html
+++ b/htdocs/index.html
@@ -136,10 +136,6 @@
 
           <div class="panel panel-primary sticky">
             <!-- Default panel contents -->
-            <div class="panel-heading">
-              <b id="panel-heading">Queue</b>
-              <b id="panel-heading-info" class="text pull-right"></b>
-            </div>
             <div class="panel-body">
               <h1>
                 <span
@@ -170,6 +166,10 @@
           <!-- /.panel -->
           <!-- /.panel-body -->
           <div class="panel panel-primary">
+            <div class="panel-heading">
+              <b id="panel-heading">Queue</b>
+              <b id="panel-heading-info" class="text pull-right"></b>
+            </div>
             <ol id="breadcrump" class="breadcrumb"></ol>
 
             <div class="col-md-12" id="filter"></div>

--- a/htdocs/js/mpd.js
+++ b/htdocs/js/mpd.js
@@ -113,6 +113,10 @@ var app = $.sammy(function () {
             );
             full_path += '/';
         });
+
+        // Remove the Queue Length Total
+        $('#panel-heading-info').empty();
+
         $('#browse').addClass('active');
     });
 


### PR DESCRIPTION
This change set moves the header that displays the Queue / Queue Time and the Browse Path to the top of the panel that contains the song lists. Seems a bit more 'intuitive'. This also removes the queue length total from displaying in the Browse tab. Kinda torn about that as having the enqueued length is rather nice but it was being displayed in a manner that makes you think it was displaying the length of the songs in the current directory.

Prior:
![image](https://user-images.githubusercontent.com/6440979/169564668-c67c5da8-3082-4b1e-b9c0-54b7f93ed5c1.png)

Now:
![image](https://user-images.githubusercontent.com/6440979/169564352-66a0c85d-2407-47a1-882b-ea49f8ba1568.png)
